### PR TITLE
fix(storage): remove duplicate deleteToken() declaration in UserStora…

### DIFF
--- a/src/Storage/UserStorageInterface.php
+++ b/src/Storage/UserStorageInterface.php
@@ -63,12 +63,6 @@ interface UserStorageInterface
     public function deleteTokensByUserId(int $userId): int;
 
     /**
-     * Delete a single token, if you nie masz tej metody
-     * (jeśli już masz, zostaw jak jest).
-     */
-    public function deleteToken(string $token): int;
-
-    /**
      * Create the necessary database schema for user storage.
      *
      * This method should be called to initialize the storage system.


### PR DESCRIPTION
…geInterface

The interface accidentally declared deleteToken() twice, causing a fatal error on load. This commit removes the duplicate and keeps a single correct signature:

    public function deleteToken(string $token): int;

No API changes beyond removing the duplicate; existing implementations remain valid.