### PR TITLE
feat(v2): extensible login pipeline, credential providers, challenge flows, clock injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,204 +1,239 @@
 # AuthKit
 
-AuthKit is a lightweight, extensible PHP authentication library with:
+Lightweight, extensible PHP 8.1+ authentication library.
 
 - Registration & login with secure password hashing
-- Server-side **session tokens** (UUID) stored in DB with optional **TTL**
-- Pluggable storage backend (**PDO** reference implementation)
-- Optional **hooks** for policy & audit (rate-limit, IP checks, logging, etc.)
-- Flexible user model (`User::get($fields)` / `User::getAll()`); helpers `getId()`, `getEmail()`
-- Admin features: **force logout** by user/token/email
+- Server-side session tokens stored in DB with optional TTL
+- Pluggable **login extension pipeline** — deny or challenge after credentials pass
+- Multi-step **challenge flows** (MFA, email activation, device check, etc.)
+- Pluggable **credential provider** — local PDO default, Cognito/Keycloak as external packages
+- Pluggable **password hasher** — `NativePasswordHasher` default
+- Pluggable **token transport** — PHP session (web) or Bearer header (API)
+- Pluggable **user ID policy** — auto-increment default, UUID in your app
+- Optional **hooks** for audit and policy (rate-limit, IP checks, logging)
+- Admin features: force logout by user / token / email
 
-> Designed for apps using Slim/Laminas/Symfony or plain PHP. Works with SQLite and MySQL.
+> Works with MySQL/MariaDB and SQLite. Designed for Slim, Laminas, Symfony or plain PHP.
 
 ---
 
-## 🚀 Installation
+## Installation
 
 ```bash
 composer require rafalmasiarek/authkit
 ```
 
-Your `composer.json` should map:
-
-```json
-{
-  "autoload": {
-    "psr-4": {
-      "AuthKit\\": "src/"
-    }
-  }
-}
-```
-
-Then:
-
-```bash
-composer dump-autoload -o
-```
-
 ---
 
-## 💾 Storage Model (Users & Sessions)
-
-AuthKit separates **users** from **sessions**. After a successful login, a random **UUID v4 token** is generated and stored in the `sessions` table. The token may have an **expiration** (`expires_at`, optional). The token is also saved in `$_SESSION[$sessionKey]` (default `auth_token`) to reference the DB session.
-
-### Tables
-
-- `users` — app user records (email, password hash, flags, custom fields)
-- `sessions` — active logins (user_id, token, created_at, expires_at, optional IP/UA)
-
-You’ll need both tables.
-
----
-
-### SQLite DDL
-
-```sql
-PRAGMA foreign_keys = ON;
-
-CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL UNIQUE,
-    password_hash TEXT NOT NULL,
-    name TEXT NULL,
-    active INTEGER NOT NULL DEFAULT 1,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
-
-CREATE TRIGGER IF NOT EXISTS users_updated_at
-AFTER UPDATE ON users
-BEGIN
-    UPDATE users SET updated_at = datetime('now') WHERE id = NEW.id;
-END;
-
-CREATE TABLE IF NOT EXISTS sessions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    token TEXT NOT NULL UNIQUE,        -- UUID v4
-    ip TEXT NULL,
-    user_agent TEXT NULL,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    expires_at TEXT NULL,              -- NULL = no expiry
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
-
-CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
-CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
-```
-
----
-
-### MySQL DDL
-
-```sql
-CREATE TABLE IF NOT EXISTS users (
-  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  email VARCHAR(254) NOT NULL UNIQUE,
-  password_hash VARCHAR(255) NOT NULL,
-  name VARCHAR(190) NULL,
-  active TINYINT(1) NOT NULL DEFAULT 1,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS sessions (
-  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  user_id INT UNSIGNED NOT NULL,
-  token CHAR(36) NOT NULL UNIQUE,          -- UUID v4
-  ip VARCHAR(45) NULL,                     -- IPv4/IPv6
-  user_agent TEXT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  expires_at DATETIME NULL,
-  CONSTRAINT fk_sessions_user
-    FOREIGN KEY (user_id) REFERENCES users(id)
-    ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE INDEX idx_sessions_user_id ON sessions(user_id);
-CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);
-```
-
----
-
-## 🧩 Storage Contract (PDO reference)
-
-```php
-interface UserStorageInterface {
-    public function findByEmail(string $email): ?\AuthKit\User;
-    public function findByToken(string $token): ?\AuthKit\User;
-    public function createUser(string $email, string $passwordHash, array $fields = []): \AuthKit\User;
-    public function updateUser(\AuthKit\User $user, array $updates): \AuthKit\User;
-
-    public function storeToken(\AuthKit\User $user, string $token, ?DateTime $expiresAt): void;
-    public function deleteToken(string $token): int;
-
-    public function deleteTokensByUserId(int $userId): int;
-    // Optional: delete all except current
-    // public function deleteTokensByUserIdExcept(int $userId, string $exceptToken): int;
-}
-```
-
----
-
-## 🔧 Bootstrapping
+## Quick start
 
 ```php
 use AuthKit\Auth;
 use AuthKit\Storage\PdoUserStorage;
 
-$pdo = new PDO('sqlite:/path/to/authkit.sqlite');
+$pdo     = new PDO('sqlite:/path/to/auth.sqlite');
 $storage = new PdoUserStorage($pdo);
+$storage->createSchema(); // creates users + sessions tables
 
-// TTL semantics: 3600 = 1 hour; 0 = no expiry
-$auth = new Auth($storage, hook: null, ttlSeconds: 3600);
+$auth = new Auth($storage);
 
-// Optionally:
-$auth->setSessionKey('auth_token');
-$auth->setThrowExceptions(false);
+// Register
+$user = $auth->register('user@example.com', 'secret123');
+
+// Login
+$login = $auth->login('user@example.com', 'secret123');
+
+if ($login->isSuccess()) {
+    // session stored automatically — redirect to dashboard
+}
+
+if ($login->isFailure()) {
+    echo $login->message(); // "Invalid credentials."
+}
+
+// Current user (reads from session)
+$user = $auth->getUser(); // ?User
+
+// Logout
+$auth->logout();
 ```
 
 ---
 
-## 🧠 API
-
-### Register
+## Constructor
 
 ```php
-register(string $email, string $password, array $customFields = [], array $additionalChecks = []): User|string|null
-```
-
-### Login
-
-```php
-login(string $email, string $password, array $additionalChecks = []): ?string
-```
-
-### Current User
-
-```php
-getUser(): ?User
-isLoggedIn(): bool
-```
-
-### Logout
-
-```php
-logout(): void
-```
-
-### Force Logout
-
-```php
-forceLogoutUser(User|int $userOrId, ?string $reason = null): int
-forceLogoutEmail(string $email, ?string $reason = null): int
-forceLogoutToken(string $token, ?string $reason = null): int
+new Auth(
+    storage:          $storage,           // UserStorageInterface — required
+    hook:             null,               // HookInterface|null
+    ttlSeconds:       3600,               // int — 0 = no expiry
+    messages:         null,               // MessageProviderInterface|null
+    throwExceptions:  false,              // bool — throw AuthException on errors
+    hasher:           null,               // PasswordHasherInterface|null — default: NativePasswordHasher
+    credentials:      null,               // CredentialProviderInterface|null — default: PdoCredentialProvider
+    challengeStorage: null,               // ChallengeStorageInterface|null — required for challenge flows
+    transport:        null,               // TokenTransportInterface|null — default: PhpSessionTransport
+)
 ```
 
 ---
 
-## 🪝 Hooks
+## Login result
+
+`login()` returns a `Login` object — never throws by default.
+
+```php
+$login = $auth->login($email, $password);
+
+$login->isSuccess();        // bool
+$login->isFailure();        // bool
+$login->requiresChallenge(); // bool — set when an extension requires an extra step
+
+$login->token();            // ?string — session token on success
+$login->user();             // ?User   — on success or challenge
+$login->message();          // string  — failure reason
+$login->challengeToken();   // ?string — raw token for completeChallenge()
+$login->challengeType();    // ?string — e.g. 'mfa_totp', 'email_activation'
+```
+
+With `throwExceptions: true` — failure throws `AuthException` instead.
+
+---
+
+## Login extension pipeline
+
+Extensions run after credentials are verified. Register them with `addLoginExtension()`.
+The first deny or challenge decision terminates the pipeline.
+
+```php
+use AuthKit\Extension\LoginExtensionInterface;
+use AuthKit\LoginContext;
+use AuthKit\LoginDecision;
+
+class ActiveUserExtension implements LoginExtensionInterface
+{
+    public function decide(LoginContext $context): LoginDecision
+    {
+        if (!$context->user->get('active')) {
+            return LoginDecision::deny('Account is not active.');
+        }
+        return LoginDecision::allow();
+    }
+}
+
+$auth->addLoginExtension(new ActiveUserExtension());
+```
+
+`LoginContext` carries `$user`, `$ip`, `$userAgent`, and optional `$meta`.
+
+---
+
+## Challenge flows (MFA, email activation, etc.)
+
+An extension can require a second step instead of immediately allowing or denying.
+
+```php
+use AuthKit\Extension\ChallengeExtensionInterface;
+use AuthKit\Challenge\ChallengeRecord;
+
+class TotpExtension implements ChallengeExtensionInterface
+{
+    public function decide(LoginContext $context): LoginDecision
+    {
+        // trigger challenge — payload stored in ChallengeRecord
+        return LoginDecision::challenge('mfa_totp', [
+            'secret' => $context->user->get('totp_secret'),
+        ]);
+    }
+
+    public function supportsChallenge(string $type): bool
+    {
+        return $type === 'mfa_totp';
+    }
+
+    public function completeChallenge(ChallengeRecord $challenge, array $input): LoginDecision
+    {
+        $valid = verify_totp($challenge->payload['secret'], $input['code'] ?? '');
+        return $valid ? LoginDecision::allow() : LoginDecision::deny('Invalid code.');
+    }
+}
+```
+
+**Flow:**
+
+```php
+// Step 1 — login
+$login = $auth->login($email, $password);
+
+if ($login->requiresChallenge()) {
+    $_SESSION['challenge_token'] = $login->challengeToken();
+    // redirect to /login/mfa — type is $login->challengeType()
+}
+
+// Step 2 — verify code
+$login = $auth->completeChallenge($_SESSION['challenge_token'], ['code' => $input['code']]);
+
+if ($login->isSuccess()) {
+    // session created — redirect to dashboard
+}
+```
+
+Challenge storage must be provided:
+
+```php
+use AuthKit\Challenge\PdoChallengeStorage;
+
+$auth = new Auth($storage, challengeStorage: new PdoChallengeStorage($pdo));
+```
+
+Schema: `(new PdoChallengeStorage($pdo))->createSchema();`
+
+---
+
+## Token transport
+
+Controls how the active token is stored and read on the client side.
+
+### Web (default — PHP session)
+
+```php
+use AuthKit\Transport\PhpSessionTransport;
+
+$auth = new Auth($storage); // PhpSessionTransport('auth_token') used by default
+
+// Custom session key:
+$auth = new Auth($storage, transport: new PhpSessionTransport('my_session_key'));
+```
+
+### API (Bearer header)
+
+```php
+use AuthKit\Transport\BearerHeaderTransport;
+
+$auth = new Auth($storage, transport: new BearerHeaderTransport());
+
+// Login — return token to client in JSON
+$login = $auth->login($email, $password);
+// → ['token' => $login->token()]
+
+// Subsequent requests — client sends Authorization: Bearer <token>
+$user = $auth->getUser(); // reads from header automatically
+```
+
+---
+
+## Storage schema
+
+`PdoUserStorage::createSchema()` creates the `users` and `sessions` tables.
+`PdoChallengeStorage::createSchema()` creates `auth_challenges` (only needed for challenge flows).
+
+Both support MySQL/MariaDB and SQLite.
+
+---
+
+## Hooks
+
+All hook methods are optional — implement only what you need.
 
 ```php
 interface HookInterface {
@@ -208,40 +243,26 @@ interface HookInterface {
 
     public function onBeforeLogin(User $user): true|string;
     public function onLoginSuccess(User $user): void;
-    public function onLoginFailure(string $email, \AuthKit\Exception\AuthException $e): void;
+    public function onLoginFailure(string $email, AuthException $e): void;
 
     public function onLogout(User $user): void;
     public function onLogoutExpired(): void;
     public function onUserActive(User $user): void;
     public function onUserUpdated(User $user, array $changedFields): void;
 
-    public function onLogoutForced(int $userId, ?string $reason, int $count): void;
+    public function onLogoutForced(int|string $userId, ?string $reason, int $count): void;
 }
 ```
 
 ---
 
-## 📦 Examples
+## Force logout
 
-A runnable demo with SQLite forms is under `examples/sqlite-forms`:
-
+```php
+$auth->forceLogoutUser($userOrId);        // all sessions for a user
+$auth->forceLogoutEmail($email);          // all sessions by email
+$auth->forceLogoutToken($token);          // single session by token
 ```
-examples/sqlite-forms/
-├── bootstrap.php
-├── schema.sql
-├── index.php
-├── account.php
-├── logout.php
-└── admin.php
-```
-
-Run:
-
-```bash
-php -S 127.0.0.1:8080 -t examples/sqlite-forms
-```
-
-The example will create `authkit.sqlite` on first run.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,29 @@ new Auth(
     credentials:      null,               // CredentialProviderInterface|null — default: PdoCredentialProvider
     challengeStorage: null,               // ChallengeStorageInterface|null — required for challenge flows
     transport:        null,               // TokenTransportInterface|null — default: PhpSessionTransport
+    clock:            null,               // ClockInterface|null — custom clock; takes precedence over timezone
+    timezone:         'UTC',             // string — timezone for built-in SystemClock; ignored when clock is provided
 )
+```
+
+### Clock and timezone
+
+By default Auth uses UTC for all session and challenge expiry calculations.
+
+```php
+// Use a specific timezone with the built-in clock:
+new Auth($storage, timezone: 'Europe/Warsaw');
+
+// Inject a custom ClockInterface implementation (clock takes precedence over timezone):
+new Auth($storage, clock: $appClock);
+```
+
+`purgeExpiredTokens()` and `purgeExpired()` are maintenance operations called outside the login flow.
+They require an explicit `DateTimeImmutable $now` from the caller:
+
+```php
+$storage->purgeExpiredTokens(new \DateTimeImmutable());
+$challengeStorage->purgeExpired(new \DateTimeImmutable());
 ```
 
 ---
@@ -124,7 +146,8 @@ class ActiveUserExtension implements LoginExtensionInterface
 $auth->addLoginExtension(new ActiveUserExtension());
 ```
 
-`LoginContext` carries `$user`, `$ip`, `$userAgent`, and optional `$meta`.
+`LoginContext` carries `$user`, `$ip`, `$userAgent`, and `$credentialMeta` from the credential provider.
+Use `$context->credential('key')` to read individual metadata values.
 
 ---
 
@@ -260,6 +283,25 @@ This keeps AuthKit core storage-agnostic and avoids forcing external identity ta
 
 Both support MySQL/MariaDB and SQLite.
 
+### User ID policy
+
+`UserIdPolicyInterface` controls how user IDs are generated. The default `NullUserIdPolicy` returns `null`,
+which lets the database assign the ID via auto-increment.
+
+The built-in `createSchema()` creates an `INT AUTO_INCREMENT` primary key. If you use a string ID policy
+(e.g. UUID, ULID), you must provide your own schema with a compatible column type — for example
+`users.id CHAR(36)` and `sessions.user_id CHAR(36)`. `createSchema()` is a convenience default,
+not a requirement.
+
+### External users and nullable password_hash
+
+`password_hash` is `NULL` in the default schema. `PdoCredentialProvider` treats a `NULL` or empty hash
+as a disabled local login and returns a failure — this prevents accidental password bypass.
+
+`PdoUserStorage::createUser()` is intended for local password accounts and requires a non-empty password hash.
+External credential providers (Cognito, Keycloak, etc.) should manage user creation with their own logic,
+or insert directly with `password_hash = NULL` for users that only authenticate externally.
+
 ---
 
 ## Hooks
@@ -294,6 +336,22 @@ $auth->forceLogoutUser($userOrId);        // all sessions for a user
 $auth->forceLogoutEmail($email);          // all sessions by email
 $auth->forceLogoutToken($token);          // single session by token
 ```
+
+---
+
+## v2 breaking changes
+
+- `Auth::login()` now returns `AuthKit\Login`, not `?string`. Check `$login->isSuccess()`, `$login->isFailure()`, or `$login->requiresChallenge()`.
+- Login-time `$additionalChecks` parameter removed from `login()`. Use `LoginExtensionInterface` instead.
+- `UserStorageInterface::findByToken()` requires a second argument: `findByToken(string $token, \DateTimeImmutable $now)`.
+- `ChallengeStorageInterface::complete()` requires a second argument: `complete(ChallengeRecord $record, \DateTimeImmutable $now)`.
+- `ChallengeStorageInterface::purgeExpired()` requires `\DateTimeImmutable $now`.
+- `PdoUserStorage::purgeExpiredTokens()` requires `\DateTimeImmutable $now`.
+- `UserStorageInterface::storeToken()` accepts `?\DateTimeInterface` instead of `?\DateTime`.
+- `Auth` constructor: `$sessionKey` parameter removed — use `transport: new PhpSessionTransport('key')` instead.
+- `Auth::setSessionKey()` removed.
+- PHP `>=8.1` required (was `>=8.0`).
+- `ramsey/uuid` dependency removed — tokens are generated with `bin2hex(random_bytes(32))`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,37 @@ $user = $auth->getUser(); // reads from header automatically
 
 ---
 
+## External credential providers
+
+AuthKit core authenticates into a local `User` object. External providers such as Cognito, Keycloak, Authentik or Zitadel should map their external identity to a local user inside their own `CredentialProviderInterface` implementation.
+
+A credential provider may pass non-persistent login metadata through `CredentialResult::success($user, $meta)`. This metadata is available in login extensions through `LoginContext::credential()`.
+
+```php
+// Inside a custom CognitoCredentialProvider::verify():
+return CredentialResult::success($localUser, [
+    'provider'       => 'cognito',
+    'subject'        => $claims['sub'],
+    'groups'         => $claims['cognito:groups'] ?? [],
+    'email_verified' => $claims['email_verified'] ?? false,
+]);
+
+// Inside a login extension:
+public function decide(LoginContext $ctx): LoginDecision
+{
+    if ($ctx->credential('email_verified') === false) {
+        return LoginDecision::deny('Email address is not verified.');
+    }
+    return LoginDecision::allow();
+}
+```
+
+Users authenticated via an external provider have no local password — `password_hash` is `NULL` in the database. `PdoCredentialProvider` explicitly rejects login attempts for such accounts.
+
+This keeps AuthKit core storage-agnostic and avoids forcing external identity tables into the base package.
+
+---
+
 ## Storage schema
 
 `PdoUserStorage::createSchema()` creates the `users` and `sessions` tables.

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,8 @@
     "bin/setup"
   ],
   "require": {
-    "php": ">=8.0",
-    "ext-pdo": "*",
-    "ramsey/uuid": "^4.9"
+    "php": ">=8.1",
+    "ext-pdo": "*"
   },
   "autoload": {
     "psr-4": {

--- a/examples/mysql-demo/index.php
+++ b/examples/mysql-demo/index.php
@@ -23,11 +23,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif ($action === 'login') {
         $email = trim((string)($_POST['email'] ?? ''));
         $pass = (string)($_POST['password'] ?? '');
-        $token = $auth->login($email, $pass);
-        if ($token) {
+        $login = $auth->login($email, $pass);
+        if ($login->isSuccess()) {
             redirect('account.php');
         } else {
-            $error = "Invalid credentials.";
+            $error = $login->message();
         }
     }
 }

--- a/examples/sqlite-demo/index.php
+++ b/examples/sqlite-demo/index.php
@@ -23,11 +23,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif ($action === 'login') {
         $email = trim((string)($_POST['email'] ?? ''));
         $pass = (string)($_POST['password'] ?? '');
-        $token = $auth->login($email, $pass);
-        if ($token) {
+        $login = $auth->login($email, $pass);
+        if ($login->isSuccess()) {
             redirect('account.php');
         } else {
-            $error = "Invalid credentials.";
+            $error = $login->message();
         }
     }
 }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1,538 +1,549 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AuthKit;
 
-use AuthKit\Storage\UserStorageInterface;
+use AuthKit\Challenge\ChallengeRecord;
+use AuthKit\Challenge\ChallengeStorageInterface;
+use AuthKit\Credential\CredentialProviderInterface;
+use AuthKit\Credential\PdoCredentialProvider;
 use AuthKit\Exception\AuthException;
+use AuthKit\Extension\ChallengeExtensionInterface;
+use AuthKit\Extension\LoginExtensionInterface;
 use AuthKit\Hook\HookInterface;
-use AuthKit\Message\MessageProviderInterface;
 use AuthKit\Message\DefaultMessageProvider;
-use Ramsey\Uuid\Uuid;
+use AuthKit\Message\MessageProviderInterface;
+use AuthKit\Password\NativePasswordHasher;
+use AuthKit\Password\PasswordHasherInterface;
+use AuthKit\Storage\UserStorageInterface;
 use DateInterval;
 use DateTime;
 
-class Auth
+/**
+ * Core authentication facade.
+ *
+ * Handles registration, login (credential verification + extension pipeline),
+ * session lifecycle, and optional multi-step challenge flows (MFA, email activation, etc.).
+ *
+ * @package AuthKit
+ */
+final class Auth
 {
-  /**
-   * @var UserStorageInterface
-   */
-  // This interface is used to interact with the user storage.
-  // It provides methods to find users by email or token, create new users, update existing users,
-  // store session tokens, and delete tokens.
-  // The Auth class uses this interface to perform user authentication and management operations.
-  // The UserStorageInterface is implemented by various storage classes, such as PdoUserStorage
-  // or InMemoryUserStorage, which provide different storage backends (e.g., database, file system,
-  // in-memory).
-  // The Auth class does not depend on any specific storage implementation, allowing for flexibility
-  // in choosing the storage backend.
-  // The UserStorageInterface is designed to be simple and focused on user-related operations.
-  // It does not include methods for session management or other non-user-related operations.
-  // The Auth class handles session management separately, using the session storage provided by PHP.
-  // This allows the Auth class to be decoupled from the session management logic, making it easier
-  // to test and maintain.
-  private UserStorageInterface $repo;
+    /**
+     * @var string Session key used to store the active token.
+     */
+    private string $sessionKey = 'auth_token';
 
-  /**
-   * @var HookInterface|null
-   */
-  // This interface is used to define hooks that can be triggered at various points in the authentication
-  // process. Hooks allow for custom behavior to be executed before or after certain actions, such
-  // as user registration, login, logout, and updates.
-  // The Auth class uses this interface to call hooks defined by the user, allowing for extensibility
-  // and customization of the authentication flow.
-  // If a hook is provided, it will be called at appropriate points in the authentication process.
-  // If no hook is provided, the Auth class will not call any hooks, and the default behavior will be used.
-  // The HookInterface allows for methods like onBeforeRegister, onBeforeLogin, onRegisterSuccess,
-  // onLoginSuccess, onLogout, and onUpdate to be defined.
-  // These methods can return a boolean or a string to indicate whether the action should proceed,
-  // or to provide a custom error message.
-  // The Auth class checks if the hook is set and if the method exists before calling it.
-  // This allows for optional hooks that can be implemented by the user without affecting the core
-  // functionality of the Auth class.
-  // If the hook is not set, the Auth class will not call any hooks, and the default behavior will be used.
-  private ?HookInterface $hook;
+    /**
+     * @var bool Whether AuthException is thrown on errors instead of returning a message.
+     */
+    private bool $throwExceptions;
 
-  /**
-   * @var int
-   */
-  // This property defines the time-to-live (TTL) for the session token in seconds.
-  // It determines how long the session token will remain valid before it expires.
-  // If the TTL is set to 0, the session will not expire.
-  // If the TTL is set to a positive value, the session will expire after that many seconds.
-  private int $ttlSeconds;
+    /**
+     * @var MessageProviderInterface
+     */
+    private MessageProviderInterface $messages;
 
-  /**
-   * @var MessageProviderInterface
-   */
-  // This interface is used to provide custom error messages for various authentication-related events.
-  // It allows for flexibility in defining error messages that can be used throughout the Auth class.
-  // If a custom message provider is not provided, the Auth class will use the DefaultMessageProvider,
-  // which provides default error messages for common authentication scenarios.
-  private MessageProviderInterface $messages;
+    /**
+     * @var PasswordHasherInterface Used by register() to hash new passwords.
+     */
+    private PasswordHasherInterface $hasher;
 
-  /**
-   * @var bool
-   */
-  // This property determines whether exceptions should be thrown on authentication errors.
-  // If set to true, the Auth class will throw AuthException instances when an error occurs.
-  // If set to false, the Auth class will return error messages instead of throwing exceptions. 
-  private bool $throwExceptions = false;
+    /**
+     * @var CredentialProviderInterface Used by login() to verify credentials.
+     */
+    private CredentialProviderInterface $credentials;
 
-  /**
-   * @var string
-   */
-  // This property defines the session key used to store the authentication token in the session. 
-  private string $sessionKey = 'auth_token';
+    /**
+     * @var array<LoginExtensionInterface> Evaluated in order after credentials pass.
+     */
+    private array $loginExtensions = [];
 
-  /**
-   * Auth constructor.
-   *
-   * @param UserStorageInterface $repo
-   * @param HookInterface|null $hook
-   * @param int $ttlSeconds Time to live for the session token in seconds. Default is 3600 (1 hour).
-   * @param MessageProviderInterface|null $messages Custom message provider for error messages.
-   * @param bool $throwExceptions Whether to throw exceptions on errors or return error messages.
-   */
-  // If $ttlSeconds is 0, the session will not expire.
-  // If $ttlSeconds is negative, the session will never expire.
-  // If $ttlSeconds is positive, the session will expire after that many seconds.
-  // If $ttlSeconds is not set, it defaults to 3600 seconds (1 hour).
-  // If $messages is not set, it defaults to DefaultMessageProvider.
-  // If $hook is not set, no hooks will be called.
-  // If $throwExceptions is true, exceptions will be thrown on errors.
-  // If $throwExceptions is false, error messages will be returned instead of exceptions.
-  // If session is not started, it will be started automatically.
-  // The session key can be set using setSessionKey() method.
-  // The session key defaults to 'auth_token'.
-  // The session key can be used to store the session token in the session.
-  // The session key can be changed using setSessionKey() method.
-  // The session key is used to store the session token in the session.
-  // The session key is used to retrieve the session token from the session.
-  // The session key is used to check if the user is logged in.
-  // The session key is used to get the user from the session.
-  // The session key is used to logout the user.
-  // The session key is used to update the user in the session.
-  // The session key is used to register the user in the session.
-  // The session key is used to login the user in the session.
-  // The session key is used to check if the user is registered in the session.
-  // The session key is used to check if the user is logged in the session.
-  // The session key is used to check if the user is active in the session.   
-  public function __construct(
-    UserStorageInterface $repo,
-    ?HookInterface $hook = null,
-    int $ttlSeconds = 3600,
-    ?MessageProviderInterface $messages = null,
-    bool $throwExceptions = false
-  ) {
-    $this->repo = $repo;
-    $this->hook = $hook;
-    $this->ttlSeconds = $ttlSeconds;
-    $this->messages = $messages ?? new DefaultMessageProvider();
-    $this->throwExceptions = $throwExceptions;
+    /**
+     * @param UserStorageInterface             $storage          User persistence layer.
+     * @param HookInterface|null               $hook             Optional lifecycle hooks.
+     * @param int                              $ttlSeconds       Session TTL in seconds (0 = no expiry).
+     * @param MessageProviderInterface|null    $messages         Custom error messages.
+     * @param bool                             $throwExceptions  Throw AuthException on errors.
+     * @param PasswordHasherInterface|null     $hasher           Hasher for register() (default: NativePasswordHasher).
+     * @param CredentialProviderInterface|null $credentials      Credential verifier for login() (default: PdoCredentialProvider).
+     * @param ChallengeStorageInterface|null   $challengeStorage Required only when using challenge extensions.
+     */
+    public function __construct(
+        private readonly UserStorageInterface       $storage,
+        private readonly ?HookInterface             $hook             = null,
+        private readonly int                        $ttlSeconds       = 3600,
+        ?MessageProviderInterface                   $messages         = null,
+        bool                                        $throwExceptions  = false,
+        ?PasswordHasherInterface                    $hasher           = null,
+        ?CredentialProviderInterface                $credentials      = null,
+        private readonly ?ChallengeStorageInterface $challengeStorage = null,
+    ) {
+        $this->messages        = $messages ?? new DefaultMessageProvider();
+        $this->throwExceptions = $throwExceptions;
+        $this->hasher          = $hasher ?? new NativePasswordHasher();
+        $this->credentials     = $credentials ?? new PdoCredentialProvider($storage, $this->hasher);
 
-    if (session_status() === PHP_SESSION_NONE) {
-      session_start();
-    }
-  }
-
-
-  /**
-   * Sets whether exceptions should be thrown on authentication errors.
-   *
-   * @param bool $value True to throw exceptions, false to suppress them.
-   *
-   * @return void
-   */
-  public function setThrowExceptions(bool $value): void
-  {
-    $this->throwExceptions = $value;
-  }
-
-  /**
-   * Sets the session key used to store the authentication token.
-   *
-   * @param string $key The session key to use.
-   *
-   * @return void
-   */
-  public function setSessionKey(string $key): void
-  {
-    $this->sessionKey = $key;
-  }
-
-  /**
-   * Handles failure cases by either throwing an exception or returning an error message.
-   *
-   * @param string $message The error message to return or throw.
-   * @param callable|null $hookCallback Optional callback to execute on failure.
-   *
-   * @return string The error message if exceptions are not thrown.
-   * @throws AuthException If exceptions are enabled.
-   */
-  // This method is used to handle errors in a consistent way.
-  // It takes an error message and an optional callback.
-  // If the callback is provided, it will be called with an AuthException.
-  // If exceptions are enabled, it will throw an AuthException with the message.
-  // If exceptions are not enabled, it will return the error message.
-  // This allows the caller to handle errors in a consistent way, either by catching exceptions or
-  // by checking the return value for an error message.
-  // The callback can be used to perform additional actions on failure, such as logging the error
-  // or notifying the user.
-  // The callback is called with an AuthException instance, which contains the error message.
-  // This allows the callback to access the error message and perform additional actions based on it.
-  // If the callback is not provided, it will not be called.
-  // This method is used in various places in the Auth class to handle errors consistently.
-  // It is used in the register() and login() methods to handle errors during user registration
-  // and login.
-  private function fail(string $message, ?callable $hookCallback = null): string
-  {
-    if ($hookCallback !== null) {
-      $hookCallback(new AuthException($message));
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
     }
 
-    if ($this->throwExceptions) {
-      throw new AuthException($message);
+    /**
+     * Register a login extension to be evaluated after credentials pass.
+     *
+     * Extensions are evaluated in registration order.
+     * The first deny or challenge decision terminates the pipeline.
+     *
+     * @param  LoginExtensionInterface $extension
+     * @return void
+     */
+    public function addLoginExtension(LoginExtensionInterface $extension): void
+    {
+        $this->loginExtensions[] = $extension;
     }
 
-    return $message;
-  }
-
-  /**
-   * Registers a new user with the provided email and password.
-   *
-   * @param string $email The user's email address.
-   * @param string $password The user's password.
-   * @param array $customFields Optional custom fields to store with the user.
-   * @param array $additionalChecks Optional additional checks to perform before registration.
-   *
-   * @return User|string|null Returns the created User object, or an error message if registration fails.
-   */
-  // The $customFields parameter allows you to store additional user data during registration.
-  // The $additionalChecks parameter allows you to perform custom validation or checks before registration.
-  // If the user already exists, it returns an error message.
-  // If the registration is blocked by a hook or additional check, it returns an error message.
-  // If the password hashing fails, it returns an error message.  
-  public function register(string $email, string $password, array $customFields = [], array $additionalChecks = []): User|string|null
-  {
-    if ($this->repo->findByEmail($email)) {
-      return $this->fail(
-        $this->messages->userAlreadyExists(),
-        fn($ex) => $this->hook && method_exists($this->hook, 'onRegisterFailure')
-          ? $this->hook->onRegisterFailure($email, $ex)
-          : null
-      );
+    /**
+     * Set whether AuthException is thrown on authentication errors.
+     *
+     * @param  bool $value
+     * @return void
+     */
+    public function setThrowExceptions(bool $value): void
+    {
+        $this->throwExceptions = $value;
     }
 
-    if ($this->hook && method_exists($this->hook, 'onBeforeRegister')) {
-      $result = $this->hook->onBeforeRegister($email, $password, $customFields);
-      if ($result !== true) {
-        $message = is_string($result) ? $result : $this->messages->registrationBlocked();
-        return $this->fail(
-          $message,
-          fn($ex) => $this->hook && method_exists($this->hook, 'onRegisterFailure')
-            ? $this->hook->onRegisterFailure($email, $ex)
-            : null
+    /**
+     * Set the session key used to store the active token.
+     *
+     * @param  string $key
+     * @return void
+     */
+    public function setSessionKey(string $key): void
+    {
+        $this->sessionKey = $key;
+    }
+
+    /**
+     * Register a new user.
+     *
+     * @param  string               $email           User's email address.
+     * @param  string               $password        Plain-text password.
+     * @param  array<string, mixed> $customFields    Additional fields to persist.
+     * @param  array<callable>      $additionalChecks Legacy pre-registration callbacks.
+     * @return User|string|null Created User on success, or an error message on failure.
+     * @throws AuthException When $throwExceptions is true and an error occurs.
+     */
+    public function register(string $email, string $password, array $customFields = [], array $additionalChecks = []): User|string|null
+    {
+        if ($this->storage->findByEmail($email)) {
+            return $this->fail(
+                $this->messages->userAlreadyExists(),
+                fn($ex) => $this->callHook('onRegisterFailure', $email, $ex),
+            );
+        }
+
+        $beforeResult = $this->callHookResult('onBeforeRegister', $email, $password, $customFields);
+        if ($beforeResult !== true) {
+            $message = is_string($beforeResult) ? $beforeResult : $this->messages->registrationBlocked();
+            return $this->fail($message, fn($ex) => $this->callHook('onRegisterFailure', $email, $ex));
+        }
+
+        foreach ($additionalChecks as $check) {
+            $result = $check($email, $password, $customFields);
+            if ($result !== true) {
+                $message = is_string($result) ? $result : $this->messages->registrationBlocked();
+                return $this->fail($message, fn($ex) => $this->callHook('onRegisterFailure', $email, $ex));
+            }
+        }
+
+        try {
+            $user = $this->storage->createUser($email, $this->hasher->hash($password), $customFields);
+        } catch (\Throwable $e) {
+            return $this->fail($e->getMessage(), fn($ex) => $this->callHook('onRegisterFailure', $email, $ex));
+        }
+
+        $this->callHook('onRegisterSuccess', $user);
+
+        return $user;
+    }
+
+    /**
+     * Verify credentials and run the login extension pipeline.
+     *
+     * Returns a Login in one of three states:
+     *  - success        : session created, token available.
+     *  - failure        : credentials invalid or an extension denied.
+     *  - challengeRequired : credentials valid but an extension requires an extra step.
+     *
+     * @param  string $email    User's email address.
+     * @param  string $password Plain-text password.
+     * @return Login
+     * @throws AuthException When $throwExceptions is true and login is rejected.
+     */
+    public function login(string $email, string $password): Login
+    {
+        $result = $this->credentials->verify(['email' => $email, 'password' => $password]);
+
+        if (!$result->isSuccess()) {
+            $this->callHook('onLoginFailure', $email, new AuthException($result->message()));
+            return $this->loginFailure($result->message());
+        }
+
+        $user    = $result->user();
+        $context = new LoginContext(
+            user:      $user,
+            ip:        $_SERVER['REMOTE_ADDR'] ?? '',
+            userAgent: $_SERVER['HTTP_USER_AGENT'] ?? '',
         );
-      }
+
+        $beforeResult = $this->callHookResult('onBeforeLogin', $user);
+        if ($beforeResult !== true) {
+            $message = is_string($beforeResult) ? $beforeResult : $this->messages->loginBlocked();
+            $this->callHook('onLoginFailure', $email, new AuthException($message));
+            return $this->loginFailure($message);
+        }
+
+        foreach ($this->loginExtensions as $extension) {
+            $decision = $extension->decide($context);
+
+            if ($decision->isDeny()) {
+                $message = $decision->reason() ?? $this->messages->loginBlocked();
+                $this->callHook('onLoginFailure', $email, new AuthException($message));
+                return $this->loginFailure($message);
+            }
+
+            if ($decision->isChallenge()) {
+                return $this->issueChallenge($user, $context, $decision);
+            }
+        }
+
+        return $this->createSession($user);
     }
 
-    foreach ($additionalChecks as $check) {
-      if (!is_callable($check)) {
-        return $this->fail(
-          "Additional check is not callable.",
-          fn($ex) => $this->hook && method_exists($this->hook, 'onRegisterFailure')
-            ? $this->hook->onRegisterFailure($email, $ex)
-            : null
+    /**
+     * Complete a pending challenge step and create a session on success.
+     *
+     * @param  string               $challengeToken Raw token stored client-side (e.g. $_SESSION['authkit_challenge']).
+     * @param  array<string, mixed> $input          User-supplied verification data.
+     * @return Login
+     * @throws AuthException        When $throwExceptions is true and verification fails.
+     * @throws \RuntimeException    When no ChallengeStorageInterface is configured.
+     */
+    public function completeChallenge(string $challengeToken, array $input): Login
+    {
+        if ($this->challengeStorage === null) {
+            throw new \RuntimeException('A ChallengeStorageInterface must be provided to use challenge flows.');
+        }
+
+        $challenge = $this->challengeStorage->findByToken($challengeToken);
+
+        if ($challenge === null || $challenge->isExpired() || $challenge->isCompleted()) {
+            return $this->loginFailure($this->messages->invalidCredentials());
+        }
+
+        if ($challenge->isExhausted()) {
+            return $this->loginFailure($this->messages->loginBlocked());
+        }
+
+        $extension = $this->findChallengeExtension($challenge->type);
+        if ($extension === null) {
+            return $this->loginFailure('Unsupported challenge type.');
+        }
+
+        $decision = $extension->completeChallenge($challenge, $input);
+
+        if ($decision->isDeny()) {
+            $this->challengeStorage->incrementAttempts($challenge);
+            return $this->loginFailure($decision->reason() ?? $this->messages->invalidCredentials());
+        }
+
+        $this->challengeStorage->complete($challenge);
+
+        $user = $this->storage->findById($challenge->userId);
+        if ($user === null) {
+            return $this->loginFailure($this->messages->invalidCredentials());
+        }
+
+        return $this->createSession($user);
+    }
+
+    /**
+     * Check whether a user is currently logged in.
+     *
+     * @return bool
+     */
+    public function isLoggedIn(): bool
+    {
+        return $this->getUser() !== null;
+    }
+
+    /**
+     * Retrieve the currently logged-in user from the active session.
+     *
+     * @return User|null
+     */
+    public function getUser(): ?User
+    {
+        if (empty($_SESSION[$this->sessionKey])) {
+            return null;
+        }
+
+        $user = $this->storage->findByToken((string) $_SESSION[$this->sessionKey]);
+
+        if ($user === null) {
+            unset($_SESSION[$this->sessionKey]);
+            $this->callHook('onLogoutExpired');
+            return null;
+        }
+
+        $this->callHook('onUserActive', $user);
+
+        return $user;
+    }
+
+    /**
+     * Log out the currently logged-in user.
+     *
+     * @return void
+     */
+    public function logout(): void
+    {
+        $user = $this->getUser();
+
+        if ($user !== null) {
+            $this->callHook('onLogout', $user);
+        }
+
+        if (!empty($_SESSION[$this->sessionKey])) {
+            $this->storage->deleteToken($_SESSION[$this->sessionKey]);
+        }
+
+        unset($_SESSION[$this->sessionKey]);
+    }
+
+    /**
+     * Invalidate all sessions for a user across every device.
+     *
+     * @param  User|int|string $userOrId User object or ID.
+     * @param  string|null     $reason   Optional audit reason passed to the hook.
+     * @return int Number of invalidated sessions.
+     */
+    public function forceLogoutUser(User|int|string $userOrId, ?string $reason = null): int
+    {
+        $userId = $userOrId instanceof User ? $userOrId->getId() : $userOrId;
+        $count  = $this->storage->deleteTokensByUserId($userId);
+
+        $current = $this->getUser();
+        if ($current !== null && $current->getId() === $userId) {
+            $this->callHook('onLogout', $current);
+            unset($_SESSION[$this->sessionKey]);
+        }
+
+        $this->callHook('onLogoutForced', $userId, $reason, $count);
+
+        return $count;
+    }
+
+    /**
+     * Invalidate a single session by its token.
+     *
+     * @param  string      $token  Session token to revoke.
+     * @param  string|null $reason Optional audit reason.
+     * @return int 1 if removed, 0 otherwise.
+     */
+    public function forceLogoutToken(string $token, ?string $reason = null): int
+    {
+        $user    = $this->storage->findByToken($token);
+        $removed = $this->storage->deleteToken($token);
+
+        if (!empty($_SESSION[$this->sessionKey]) && hash_equals($_SESSION[$this->sessionKey], $token)) {
+            if ($user !== null) {
+                $this->callHook('onLogout', $user);
+            }
+            unset($_SESSION[$this->sessionKey]);
+        }
+
+        if ($user !== null) {
+            $this->callHook('onLogoutForced', $user->getId(), $reason, $removed);
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Invalidate all sessions for a user identified by email.
+     *
+     * @param  string      $email
+     * @param  string|null $reason Optional audit reason.
+     * @return int Number of invalidated sessions.
+     */
+    public function forceLogoutEmail(string $email, ?string $reason = null): int
+    {
+        $user = $this->storage->findByEmail($email);
+
+        return $user !== null ? $this->forceLogoutUser($user, $reason) : 0;
+    }
+
+    /**
+     * Update fields on a user record.
+     *
+     * @param  User                 $user    User to update.
+     * @param  array<string, mixed> $updates Fields to update.
+     * @return User Updated user.
+     */
+    public function updateUser(User $user, array $updates): User
+    {
+        $updated = $this->storage->updateUser($user, $updates);
+        $this->callHook('onUserUpdated', $updated, array_keys($updates));
+
+        return $updated;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a session, persist the token, and store it in $_SESSION.
+     *
+     * @param  User $user
+     * @return Login
+     */
+    private function createSession(User $user): Login
+    {
+        $token     = bin2hex(random_bytes(32));
+        $expiresAt = $this->ttlSeconds > 0
+            ? (new DateTime())->add(new DateInterval("PT{$this->ttlSeconds}S"))
+            : null;
+
+        $this->storage->storeToken($user, $token, $expiresAt);
+        $this->callHook('onLoginSuccess', $user);
+
+        $_SESSION[$this->sessionKey] = $token;
+
+        return Login::success($token, $user);
+    }
+
+    /**
+     * Store a ChallengeRecord and return a challengeRequired Login.
+     *
+     * @param  User          $user
+     * @param  LoginContext  $context
+     * @param  LoginDecision $decision
+     * @return Login
+     * @throws \RuntimeException When no ChallengeStorageInterface is configured.
+     */
+    private function issueChallenge(User $user, LoginContext $context, LoginDecision $decision): Login
+    {
+        if ($this->challengeStorage === null) {
+            throw new \RuntimeException('A ChallengeStorageInterface must be provided to use challenge flows.');
+        }
+
+        $rawToken = bin2hex(random_bytes(32));
+        $type     = (string) $decision->challengeType();
+
+        $record = new ChallengeRecord(
+            id:          bin2hex(random_bytes(16)),
+            userId:      $user->getId() ?? '',
+            type:        $type,
+            payload:     $decision->challengePayload(),
+            maxAttempts: 5,
+            expiresAt:   (new DateTime())->add(new DateInterval('PT15M')),
+            ip:          $context->ip,
+            userAgent:   $context->userAgent,
         );
-      }
 
-      $result = $check($email, $password, $customFields);
-      if ($result !== true) {
-        $message = is_string($result) ? $result : $this->messages->registrationBlocked();
-        return $this->fail(
-          $message,
-          fn($ex) => $this->hook && method_exists($this->hook, 'onRegisterFailure')
-            ? $this->hook->onRegisterFailure($email, $ex)
-            : null
-        );
-      }
+        $this->challengeStorage->store($record, $rawToken);
+
+        return Login::challengeRequired($rawToken, $type, $user);
     }
 
-    $hash = password_hash($password, PASSWORD_DEFAULT);
-    if (!$hash) {
-      return $this->fail(
-        $this->messages->passwordHashingFailed(),
-        fn($ex) => $this->hook && method_exists($this->hook, 'onRegisterFailure')
-          ? $this->hook->onRegisterFailure($email, $ex)
-          : null
-      );
+    /**
+     * Find the first registered extension that handles the given challenge type.
+     *
+     * @param  string $type
+     * @return ChallengeExtensionInterface|null
+     */
+    private function findChallengeExtension(string $type): ?ChallengeExtensionInterface
+    {
+        foreach ($this->loginExtensions as $extension) {
+            if ($extension instanceof ChallengeExtensionInterface && $extension->supportsChallenge($type)) {
+                return $extension;
+            }
+        }
+
+        return null;
     }
 
-    try {
-      $user = $this->repo->createUser($email, $hash, $customFields);
-    } catch (\Throwable $e) {
-      return $this->fail(
-        $e->getMessage(),
-        fn($ex) => $this->hook && method_exists($this->hook, 'onRegisterFailure')
-          ? $this->hook->onRegisterFailure($email, $ex)
-          : null
-      );
+    /**
+     * Return Login::failure() and optionally throw AuthException.
+     *
+     * @param  string $message
+     * @return Login
+     * @throws AuthException
+     */
+    private function loginFailure(string $message): Login
+    {
+        if ($this->throwExceptions) {
+            throw new AuthException($message);
+        }
+
+        return Login::failure($message);
     }
 
-    if ($this->hook && method_exists($this->hook, 'onRegisterSuccess')) {
-      $this->hook->onRegisterSuccess($user);
+    /**
+     * Handle register-time failure: invoke hook callback, then throw or return message.
+     *
+     * @param  string        $message
+     * @param  callable|null $hookCallback
+     * @return string
+     * @throws AuthException
+     */
+    private function fail(string $message, ?callable $hookCallback = null): string
+    {
+        if ($hookCallback !== null) {
+            $hookCallback(new AuthException($message));
+        }
+
+        if ($this->throwExceptions) {
+            throw new AuthException($message);
+        }
+
+        return $message;
     }
 
-    return $user;
-  }
-
-  /**
-   * Logs in a user with the provided email and password.
-   *
-   * @param string $email The user's email address.
-   * @param string $password The user's password.
-   * @param array $additionalChecks Optional additional checks to perform before login.
-   *
-   * @return string|null Returns the session token if login is successful, or an error message if it fails.
-   */
-  // The $additionalChecks parameter allows you to perform custom validation or checks before login.
-  // If the user is not found or the password is incorrect, it returns an error message.
-  // If the login is blocked by a hook or additional check, it returns an error message.
-  // If the session token is successfully created, it returns the token.
-  // If the session token is not created, it returns an error message.
-  // If the user is already logged in, it returns the existing session token. x
-  public function login(string $email, string $password, array $additionalChecks = []): string|null
-  {
-    $user = $this->repo->findByEmail($email);
-
-    if (!$user || !password_verify($password, $user->get('password_hash'))) {
-      return $this->fail(
-        $this->messages->invalidCredentials(),
-        fn($e) => $this->hook && method_exists($this->hook, 'onLoginFailure')
-          ? $this->hook->onLoginFailure($email, $e)
-          : null
-      );
+    /**
+     * Call a hook method if the hook is configured and the method exists.
+     *
+     * @param  string $method
+     * @param  mixed  ...$args
+     * @return void
+     */
+    private function callHook(string $method, mixed ...$args): void
+    {
+        if ($this->hook !== null && method_exists($this->hook, $method)) {
+            $this->hook->{$method}(...$args);
+        }
     }
 
-    if ($this->hook && method_exists($this->hook, 'onBeforeLogin')) {
-      $result = $this->hook->onBeforeLogin($user);
-      if ($result !== true) {
-        $message = is_string($result) ? $result : $this->messages->loginBlocked();
-        return $this->fail(
-          $message,
-          fn($e) => $this->hook && method_exists($this->hook, 'onLoginFailure')
-            ? $this->hook->onLoginFailure($email, $e)
-            : null
-        );
-      }
+    /**
+     * Call a hook method that returns a pass/fail result.
+     *
+     * Returns true when no hook is configured (meaning: proceed).
+     *
+     * @param  string $method
+     * @param  mixed  ...$args
+     * @return mixed
+     */
+    private function callHookResult(string $method, mixed ...$args): mixed
+    {
+        if ($this->hook !== null && method_exists($this->hook, $method)) {
+            return $this->hook->{$method}(...$args);
+        }
+
+        return true;
     }
-
-    foreach ($additionalChecks as $check) {
-      if (!is_callable($check)) {
-        return $this->fail(
-          "Additional check is not callable.",
-          fn($e) => $this->hook && method_exists($this->hook, 'onLoginFailure')
-            ? $this->hook->onLoginFailure($email, $e)
-            : null
-        );
-      }
-
-      $result = $check($user);
-      if ($result !== true) {
-        $message = is_string($result) ? $result : $this->messages->loginBlocked();
-        return $this->fail(
-          $message,
-          fn($e) => $this->hook && method_exists($this->hook, 'onLoginFailure')
-            ? $this->hook->onLoginFailure($email, $e)
-            : null
-        );
-      }
-    }
-
-    $token = Uuid::uuid4()->toString();
-    $expiresAt = $this->ttlSeconds > 0 ? (new DateTime())->add(new DateInterval("PT{$this->ttlSeconds}S")) : null;
-
-    $this->repo->storeToken($user, $token, $expiresAt);
-
-    if ($this->hook && method_exists($this->hook, 'onLoginSuccess')) {
-      $this->hook->onLoginSuccess($user);
-    }
-
-    $_SESSION[$this->sessionKey] = $token;
-
-    return $token;
-  }
-
-  /**
-   * Checks if the user is currently logged in.
-   *
-   * @return bool Returns true if the user is logged in, false otherwise.
-   */
-  public function isLoggedIn(): bool
-  {
-    return $this->getUser() !== null;
-  }
-
-  /**
-   * Retrieves the currently logged-in user.
-   *
-   * @return User|null Returns the User object if logged in, or null if not.
-   */
-  public function getUser(): ?User
-  {
-    if (empty($_SESSION[$this->sessionKey])) {
-      return null;
-    }
-
-    $token  = (string) $_SESSION[$this->sessionKey];
-    $user   = $this->repo->findByToken($token);
-
-    if (!$user) {
-      // Treat as expired/invalid session: cleanup + optional hook
-      unset($_SESSION[$this->sessionKey]);
-      if ($this->hook && method_exists($this->hook, 'onLogoutExpired')) {
-        $this->hook->onLogoutExpired();
-      }
-      return null;
-    }
-
-    if ($this->hook && method_exists($this->hook, 'onUserActive')) {
-      $this->hook->onUserActive($user);
-    }
-
-    return $user;
-  }
-
-  /**
-   * Logs out the currently logged-in user.
-   *
-   * @return void
-   */
-  // This method deletes the session token from the storage and unsets the session variable.
-  // It also calls the onLogout hook if it exists.
-  // If the user is not logged in, it does nothing.
-  // If the user is logged in, it deletes the session token from the storage and unsets the session variable.
-  public function logout(): void
-  {
-    $user = $this->getUser();
-    if ($user && $this->hook && method_exists($this->hook, 'onLogout')) {
-      $this->hook->onLogout($user);
-    }
-
-    if (!empty($_SESSION[$this->sessionKey])) {
-      $this->repo->deleteToken($_SESSION[$this->sessionKey]);
-    }
-
-    unset($_SESSION[$this->sessionKey]);
-  }
-
-  /**
-   * Force-logout: invalidate ALL sessions of the given user (every device).
-   * Accepts User or user id. Returns number of invalidated sessions.
-   */
-  public function forceLogoutUser(User|int $userOrId, ?string $reason = null): int
-  {
-    $userId = $userOrId instanceof User ? (int)$userOrId->get('id') : (int)$userOrId;
-
-    // Storage-level revoke
-    $count = $this->repo->deleteTokensByUserId($userId);
-
-    // If the currently logged-in session belongs to that user — also clear PHP session.
-    $current = $this->getUser();
-    if ($current && (int)$current->get('id') === $userId) {
-      // Optional: call onLogout hook for the *current* device
-      if ($this->hook && method_exists($this->hook, 'onLogout')) {
-        $this->hook->onLogout($current);
-      }
-      unset($_SESSION[$this->sessionKey]);
-    }
-
-    // Optional: admin/audit hook
-    if ($this->hook && method_exists($this->hook, 'onLogoutForced')) {
-      // Call once, not per token
-      // You can pass a lightweight user stub if you don't want another fetch
-      $this->hook->onLogoutForced($userId, $reason, $count);
-    }
-
-    return $count;
-  }
-
-  /**
-   * Force-logout by token (single device/session).
-   * Returns 1 if removed, 0 otherwise.
-   */
-  public function forceLogoutToken(string $token, ?string $reason = null): int
-  {
-    // Best-effort: try to resolve user for hook
-    $user = $this->repo->findByToken($token);
-
-    $removed = (int) $this->repo->deleteToken($token);
-
-    // If we just killed our own current token – clear PHP session
-    if (!empty($_SESSION[$this->sessionKey]) && hash_equals($_SESSION[$this->sessionKey], $token)) {
-      if ($user && $this->hook && method_exists($this->hook, 'onLogout')) {
-        $this->hook->onLogout($user);
-      }
-      unset($_SESSION[$this->sessionKey]);
-    }
-
-    if ($user && $this->hook && method_exists($this->hook, 'onLogoutForced')) {
-      $this->hook->onLogoutForced((int)$user->get('id'), $reason, $removed);
-    }
-
-    return $removed;
-  }
-
-  /**
-   * Convenience: force-logout by email (all sessions).
-   */
-  public function forceLogoutEmail(string $email, ?string $reason = null): int
-  {
-    $user = $this->repo->findByEmail($email);
-    if (!$user) {
-      return 0;
-    }
-    return $this->forceLogoutUser($user, $reason);
-  }
-
-  /**
-   * Updates the user's information.
-   *
-   * @param User $user The user object to update.
-   * @param array $updates Associative array of fields to update.
-   *
-   * @return User Returns the updated User object.
-   */
-  // This method updates the user information in the storage.
-  // It takes a User object and an associative array of fields to update.
-  // It calls the updateUser method of the storage interface.
-  // If the hook is set and has an onUserUpdated method, it calls that method
-  // with the updated user and the keys of the updates array.
-  // It returns the updated User object.
-  // The updates array can contain any fields that are allowed to be updated.
-  // The User object must be a valid user that exists in the storage.
-  // The updates array must contain valid fields that can be updated.
-  // If the updates array is empty, it returns the original user without changes.
-  // If the user does not exist in the storage, it throws an exception.
-  // If the user exists but the updates array is empty, it returns the original user without changes.
-  // If the user exists and the updates array is not empty, it updates the user
-  // and returns the updated User object.
-  // If the user exists and the updates array is not empty, it updates the user
-  // and returns the updated User object.
-  // If the user exists and the updates array is not empty, it updates the user
-  // and returns the updated User object.
-  // If the user exists and the updates array is not empty, it updates the user
-  // and returns the updated User object.
-  // If the user exists and the updates array is not empty, it updates the user
-  // and returns the updated User object. 
-  public function updateUser(User $user, array $updates): User
-  {
-    $updatedUser = $this->repo->updateUser($user, $updates);
-
-    if ($this->hook && method_exists($this->hook, 'onUserUpdated')) {
-      $this->hook->onUserUpdated($updatedUser, array_keys($updates));
-    }
-
-    return $updatedUser;
-  }
 }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -17,6 +17,8 @@ use AuthKit\Message\MessageProviderInterface;
 use AuthKit\Password\NativePasswordHasher;
 use AuthKit\Password\PasswordHasherInterface;
 use AuthKit\Storage\UserStorageInterface;
+use AuthKit\Transport\PhpSessionTransport;
+use AuthKit\Transport\TokenTransportInterface;
 use DateInterval;
 use DateTime;
 
@@ -30,11 +32,6 @@ use DateTime;
  */
 final class Auth
 {
-    /**
-     * @var string Session key used to store the active token.
-     */
-    private string $sessionKey = 'auth_token';
-
     /**
      * @var bool Whether AuthException is thrown on errors instead of returning a message.
      */
@@ -56,6 +53,11 @@ final class Auth
     private CredentialProviderInterface $credentials;
 
     /**
+     * @var TokenTransportInterface Handles reading and writing the active token.
+     */
+    private TokenTransportInterface $transport;
+
+    /**
      * @var array<LoginExtensionInterface> Evaluated in order after credentials pass.
      */
     private array $loginExtensions = [];
@@ -69,6 +71,7 @@ final class Auth
      * @param PasswordHasherInterface|null     $hasher           Hasher for register() (default: NativePasswordHasher).
      * @param CredentialProviderInterface|null $credentials      Credential verifier for login() (default: PdoCredentialProvider).
      * @param ChallengeStorageInterface|null   $challengeStorage Required only when using challenge extensions.
+     * @param TokenTransportInterface|null     $transport        Token read/write transport (default: PhpSessionTransport).
      */
     public function __construct(
         private readonly UserStorageInterface       $storage,
@@ -79,15 +82,14 @@ final class Auth
         ?PasswordHasherInterface                    $hasher           = null,
         ?CredentialProviderInterface                $credentials      = null,
         private readonly ?ChallengeStorageInterface $challengeStorage = null,
+        ?TokenTransportInterface                    $transport        = null,
     ) {
         $this->messages        = $messages ?? new DefaultMessageProvider();
         $this->throwExceptions = $throwExceptions;
         $this->hasher          = $hasher ?? new NativePasswordHasher();
         $this->credentials     = $credentials ?? new PdoCredentialProvider($storage, $this->hasher);
-
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
+        $this->transport       = $transport ?? new PhpSessionTransport();
+        $this->transport->initialize();
     }
 
     /**
@@ -113,17 +115,6 @@ final class Auth
     public function setThrowExceptions(bool $value): void
     {
         $this->throwExceptions = $value;
-    }
-
-    /**
-     * Set the session key used to store the active token.
-     *
-     * @param  string $key
-     * @return void
-     */
-    public function setSessionKey(string $key): void
-    {
-        $this->sessionKey = $key;
     }
 
     /**
@@ -287,14 +278,16 @@ final class Auth
      */
     public function getUser(): ?User
     {
-        if (empty($_SESSION[$this->sessionKey])) {
+        $token = $this->transport->get();
+
+        if ($token === null) {
             return null;
         }
 
-        $user = $this->storage->findByToken((string) $_SESSION[$this->sessionKey]);
+        $user = $this->storage->findByToken($token);
 
         if ($user === null) {
-            unset($_SESSION[$this->sessionKey]);
+            $this->transport->clear();
             $this->callHook('onLogoutExpired');
             return null;
         }
@@ -317,11 +310,12 @@ final class Auth
             $this->callHook('onLogout', $user);
         }
 
-        if (!empty($_SESSION[$this->sessionKey])) {
-            $this->storage->deleteToken($_SESSION[$this->sessionKey]);
+        $token = $this->transport->get();
+        if ($token !== null) {
+            $this->storage->deleteToken($token);
         }
 
-        unset($_SESSION[$this->sessionKey]);
+        $this->transport->clear();
     }
 
     /**
@@ -339,7 +333,7 @@ final class Auth
         $current = $this->getUser();
         if ($current !== null && $current->getId() === $userId) {
             $this->callHook('onLogout', $current);
-            unset($_SESSION[$this->sessionKey]);
+            $this->transport->clear();
         }
 
         $this->callHook('onLogoutForced', $userId, $reason, $count);
@@ -359,11 +353,12 @@ final class Auth
         $user    = $this->storage->findByToken($token);
         $removed = $this->storage->deleteToken($token);
 
-        if (!empty($_SESSION[$this->sessionKey]) && hash_equals($_SESSION[$this->sessionKey], $token)) {
+        $current = $this->transport->get();
+        if ($current !== null && hash_equals($current, $token)) {
             if ($user !== null) {
                 $this->callHook('onLogout', $user);
             }
-            unset($_SESSION[$this->sessionKey]);
+            $this->transport->clear();
         }
 
         if ($user !== null) {
@@ -422,7 +417,7 @@ final class Auth
         $this->storage->storeToken($user, $token, $expiresAt);
         $this->callHook('onLoginSuccess', $user);
 
-        $_SESSION[$this->sessionKey] = $token;
+        $this->transport->set($token);
 
         return Login::success($token, $user);
     }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -373,7 +373,7 @@ final class Auth
      */
     public function forceLogoutToken(string $token, ?string $reason = null): int
     {
-        $user    = $this->storage->findByToken($token);
+        $user    = $this->storage->findByToken($token, $this->clock->now());
         $removed = $this->storage->deleteToken($token);
 
         $current = $this->transport->get();

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -6,6 +6,8 @@ namespace AuthKit;
 
 use AuthKit\Challenge\ChallengeRecord;
 use AuthKit\Challenge\ChallengeStorageInterface;
+use AuthKit\Clock\ClockInterface;
+use AuthKit\Clock\SystemClock;
 use AuthKit\Credential\CredentialProviderInterface;
 use AuthKit\Credential\PdoCredentialProvider;
 use AuthKit\Exception\AuthException;
@@ -20,7 +22,6 @@ use AuthKit\Storage\UserStorageInterface;
 use AuthKit\Transport\PhpSessionTransport;
 use AuthKit\Transport\TokenTransportInterface;
 use DateInterval;
-use DateTime;
 
 /**
  * Core authentication facade.
@@ -58,6 +59,11 @@ final class Auth
     private TokenTransportInterface $transport;
 
     /**
+     * @var ClockInterface Used for session and challenge expiry calculations.
+     */
+    private ClockInterface $clock;
+
+    /**
      * @var array<LoginExtensionInterface> Evaluated in order after credentials pass.
      */
     private array $loginExtensions = [];
@@ -72,6 +78,8 @@ final class Auth
      * @param CredentialProviderInterface|null $credentials      Credential verifier for login() (default: PdoCredentialProvider).
      * @param ChallengeStorageInterface|null   $challengeStorage Required only when using challenge extensions.
      * @param TokenTransportInterface|null     $transport        Token read/write transport (default: PhpSessionTransport).
+     * @param ClockInterface|null              $clock            Custom clock (takes precedence over $timezone when provided).
+     * @param string                           $timezone         Timezone for the built-in SystemClock (e.g. 'Europe/Warsaw'). Ignored when $clock is provided. Defaults to UTC.
      */
     public function __construct(
         private readonly UserStorageInterface       $storage,
@@ -83,12 +91,15 @@ final class Auth
         ?CredentialProviderInterface                $credentials      = null,
         private readonly ?ChallengeStorageInterface $challengeStorage = null,
         ?TokenTransportInterface                    $transport        = null,
+        ?ClockInterface                             $clock            = null,
+        string                                      $timezone         = 'UTC',
     ) {
         $this->messages        = $messages ?? new DefaultMessageProvider();
         $this->throwExceptions = $throwExceptions;
         $this->hasher          = $hasher ?? new NativePasswordHasher();
         $this->credentials     = $credentials ?? new PdoCredentialProvider($storage, $this->hasher);
         $this->transport       = $transport ?? new PhpSessionTransport();
+        $this->clock           = $clock ?? new SystemClock($timezone);
         $this->transport->initialize();
     }
 
@@ -176,7 +187,15 @@ final class Auth
      */
     public function login(string $email, string $password): Login
     {
-        $result = $this->credentials->verify(['email' => $email, 'password' => $password]);
+        $credentialContext = [
+            'ip'         => $_SERVER['REMOTE_ADDR'] ?? '',
+            'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
+        ];
+
+        $result = $this->credentials->verify(
+            ['email' => $email, 'password' => $password],
+            $credentialContext,
+        );
 
         if (!$result->isSuccess()) {
             $this->callHook('onLoginFailure', $email, new AuthException($result->message()));
@@ -185,9 +204,10 @@ final class Auth
 
         $user    = $result->user();
         $context = new LoginContext(
-            user:      $user,
-            ip:        $_SERVER['REMOTE_ADDR'] ?? '',
-            userAgent: $_SERVER['HTTP_USER_AGENT'] ?? '',
+            user:           $user,
+            ip:             $credentialContext['ip'],
+            userAgent:      $credentialContext['user_agent'],
+            credentialMeta: $result->meta(),
         );
 
         $beforeResult = $this->callHookResult('onBeforeLogin', $user);
@@ -246,12 +266,15 @@ final class Auth
 
         $decision = $extension->completeChallenge($challenge, $input);
 
-        if ($decision->isDeny()) {
+        if (!$decision->isAllow()) {
             $this->challengeStorage->incrementAttempts($challenge);
-            return $this->loginFailure($decision->reason() ?? $this->messages->invalidCredentials());
+            $message = $decision->isDeny()
+                ? ($decision->reason() ?? $this->messages->invalidCredentials())
+                : $this->messages->invalidCredentials();
+            return $this->loginFailure($message);
         }
 
-        $this->challengeStorage->complete($challenge);
+        $this->challengeStorage->complete($challenge, $this->clock->now());
 
         $user = $this->storage->findById($challenge->userId);
         if ($user === null) {
@@ -284,7 +307,7 @@ final class Auth
             return null;
         }
 
-        $user = $this->storage->findByToken($token);
+        $user = $this->storage->findByToken($token, $this->clock->now());
 
         if ($user === null) {
             $this->transport->clear();
@@ -411,7 +434,7 @@ final class Auth
     {
         $token     = bin2hex(random_bytes(32));
         $expiresAt = $this->ttlSeconds > 0
-            ? (new DateTime())->add(new DateInterval("PT{$this->ttlSeconds}S"))
+            ? $this->clock->now()->add(new DateInterval("PT{$this->ttlSeconds}S"))
             : null;
 
         $this->storage->storeToken($user, $token, $expiresAt);
@@ -437,23 +460,29 @@ final class Auth
             throw new \RuntimeException('A ChallengeStorageInterface must be provided to use challenge flows.');
         }
 
-        $rawToken = bin2hex(random_bytes(32));
-        $type     = (string) $decision->challengeType();
+        $rawToken        = bin2hex(random_bytes(32));
+        $type            = (string) $decision->challengeType();
+        $expiresAtSource = $decision->challengeExpiresAt();
+        $expiresAt       = $expiresAtSource !== null
+            ? \DateTime::createFromInterface($expiresAtSource)
+            : \DateTime::createFromInterface($this->clock->now()->add(new DateInterval('PT15M')));
 
         $record = new ChallengeRecord(
             id:          bin2hex(random_bytes(16)),
             userId:      $user->getId() ?? '',
             type:        $type,
             payload:     $decision->challengePayload(),
-            maxAttempts: 5,
-            expiresAt:   (new DateTime())->add(new DateInterval('PT15M')),
+            maxAttempts: $decision->challengeMaxAttempts() ?? 5,
+            expiresAt:   $expiresAt,
             ip:          $context->ip,
             userAgent:   $context->userAgent,
         );
 
         $this->challengeStorage->store($record, $rawToken);
 
-        return Login::challengeRequired($rawToken, $type, $user);
+        $message = $decision->challengeMessage();
+
+        return Login::challengeRequired($rawToken, $type, $user, $message);
     }
 
     /**

--- a/src/Challenge/ChallengeRecord.php
+++ b/src/Challenge/ChallengeRecord.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Challenge;
+
+use DateTime;
+
+/**
+ * Immutable value object representing a persisted challenge step.
+ *
+ * Created when a LoginExtensionInterface returns LoginDecision::challenge().
+ * The raw token travels exclusively on the client side; only its sha256 hash
+ * is stored in the database.
+ *
+ * @package AuthKit\Challenge
+ */
+final class ChallengeRecord
+{
+    /**
+     * @param string             $id          UUID v4 record identifier.
+     * @param int|string         $userId      ID of the user being challenged.
+     * @param string             $type        Challenge type handled by a ChallengeExtensionInterface.
+     * @param array<string,mixed>$payload     Data stored by the extension (e.g. hashed OTP, device info).
+     * @param int                $maxAttempts Maximum allowed verification attempts before exhaustion.
+     * @param DateTime           $expiresAt   Point in time when this challenge becomes invalid.
+     * @param string             $ip          Client IP at time of challenge creation.
+     * @param string             $userAgent   Client User-Agent at time of challenge creation.
+     * @param int                $attempts    Current failed attempt count (mutable after hydration).
+     * @param DateTime|null      $completedAt When the challenge was successfully completed (mutable).
+     */
+    public function __construct(
+        public readonly string     $id,
+        public readonly int|string $userId,
+        public readonly string     $type,
+        public readonly array      $payload,
+        public readonly int        $maxAttempts,
+        public readonly DateTime   $expiresAt,
+        public readonly string     $ip,
+        public readonly string     $userAgent,
+        public int                 $attempts    = 0,
+        public ?DateTime           $completedAt = null,
+    ) {
+    }
+
+    /**
+     * @return bool True when the challenge has passed its expiry time.
+     */
+    public function isExpired(): bool
+    {
+        return $this->expiresAt < new DateTime();
+    }
+
+    /**
+     * @return bool True when the maximum attempt count has been reached.
+     */
+    public function isExhausted(): bool
+    {
+        return $this->attempts >= $this->maxAttempts;
+    }
+
+    /**
+     * @return bool True when the challenge has been successfully completed.
+     */
+    public function isCompleted(): bool
+    {
+        return $this->completedAt !== null;
+    }
+}

--- a/src/Challenge/ChallengeStorageInterface.php
+++ b/src/Challenge/ChallengeStorageInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Challenge;
+
+/**
+ * Persists and retrieves challenge records for multi-step login flows.
+ *
+ * Only the sha256 hash of the raw token is stored — the raw token travels
+ * exclusively on the client side (e.g. $_SESSION['authkit_challenge']).
+ *
+ * @package AuthKit\Challenge
+ */
+interface ChallengeStorageInterface
+{
+    /**
+     * Persist a new challenge record.
+     *
+     * @param ChallengeRecord $record   Challenge data to persist.
+     * @param string          $rawToken Raw token sent to the client (sha256 hash stored in DB).
+     * @return void
+     */
+    public function store(ChallengeRecord $record, string $rawToken): void;
+
+    /**
+     * Find a non-completed challenge by its raw token.
+     *
+     * @param  string $rawToken The raw token held by the client.
+     * @return ChallengeRecord|null Null when not found or already completed.
+     */
+    public function findByToken(string $rawToken): ?ChallengeRecord;
+
+    /**
+     * Mark a challenge as successfully completed.
+     *
+     * @param  ChallengeRecord $record
+     * @return void
+     */
+    public function complete(ChallengeRecord $record): void;
+
+    /**
+     * Increment the failed attempt counter for a challenge.
+     *
+     * @param  ChallengeRecord $record
+     * @return void
+     */
+    public function incrementAttempts(ChallengeRecord $record): void;
+
+    /**
+     * Delete all expired challenge records.
+     *
+     * @return void
+     */
+    public function purgeExpired(): void;
+
+    /**
+     * Create the auth_challenges table if it does not exist.
+     *
+     * @return void
+     */
+    public function createSchema(): void;
+}

--- a/src/Challenge/ChallengeStorageInterface.php
+++ b/src/Challenge/ChallengeStorageInterface.php
@@ -34,10 +34,15 @@ interface ChallengeStorageInterface
     /**
      * Mark a challenge as successfully completed.
      *
-     * @param  ChallengeRecord $record
+     * The implementation must record $now as the completion timestamp.
+     * Pass Auth::now() or an equivalent value from your clock to keep
+     * timestamps consistent with the rest of the auth layer.
+     *
+     * @param  ChallengeRecord    $record Challenge to mark as completed.
+     * @param  \DateTimeImmutable $now    Current time used as the completed_at timestamp.
      * @return void
      */
-    public function complete(ChallengeRecord $record): void;
+    public function complete(ChallengeRecord $record, \DateTimeImmutable $now): void;
 
     /**
      * Increment the failed attempt counter for a challenge.
@@ -50,9 +55,13 @@ interface ChallengeStorageInterface
     /**
      * Delete all expired challenge records.
      *
+     * The caller is responsible for supplying the reference time.
+     * Typically called from a maintenance job or cron — not part of the login flow.
+     *
+     * @param  \DateTimeImmutable $now Records with expires_at before this value will be deleted.
      * @return void
      */
-    public function purgeExpired(): void;
+    public function purgeExpired(\DateTimeImmutable $now): void;
 
     /**
      * Create the auth_challenges table if it does not exist.

--- a/src/Challenge/PdoChallengeStorage.php
+++ b/src/Challenge/PdoChallengeStorage.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Challenge;
+
+use DateTime;
+use PDO;
+
+/**
+ * PDO-backed challenge storage supporting MySQL/MariaDB and SQLite.
+ *
+ * Token security: only sha256($rawToken) is stored. The raw token is returned
+ * to the caller and kept client-side. A DB leak cannot be used to replay challenges.
+ *
+ * @package AuthKit\Challenge
+ */
+final class PdoChallengeStorage implements ChallengeStorageInterface
+{
+    /**
+     * @param PDO $pdo Database connection.
+     */
+    public function __construct(private readonly PDO $pdo)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function store(ChallengeRecord $record, string $rawToken): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO auth_challenges
+             (id, user_id, token_hash, type, payload, attempts, max_attempts, expires_at, ip, user_agent)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        );
+
+        $stmt->execute([
+            $record->id,
+            $record->userId,
+            hash('sha256', $rawToken),
+            $record->type,
+            json_encode($record->payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+            $record->attempts,
+            $record->maxAttempts,
+            $record->expiresAt->format('Y-m-d H:i:s'),
+            $record->ip,
+            $record->userAgent,
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByToken(string $rawToken): ?ChallengeRecord
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT * FROM auth_challenges
+             WHERE token_hash = ? AND completed_at IS NULL
+             LIMIT 1'
+        );
+        $stmt->execute([hash('sha256', $rawToken)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ? $this->hydrate($row) : null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function complete(ChallengeRecord $record): void
+    {
+        $this->pdo->prepare(
+            'UPDATE auth_challenges SET completed_at = ? WHERE id = ?'
+        )->execute([(new DateTime())->format('Y-m-d H:i:s'), $record->id]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function incrementAttempts(ChallengeRecord $record): void
+    {
+        $this->pdo->prepare(
+            'UPDATE auth_challenges SET attempts = attempts + 1 WHERE id = ?'
+        )->execute([$record->id]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function purgeExpired(): void
+    {
+        $this->pdo->prepare(
+            'DELETE FROM auth_challenges WHERE expires_at < ?'
+        )->execute([(new DateTime())->format('Y-m-d H:i:s')]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createSchema(): void
+    {
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $this->pdo->exec("PRAGMA foreign_keys = ON;");
+            $this->pdo->exec("
+                CREATE TABLE IF NOT EXISTS auth_challenges (
+                    id           TEXT    NOT NULL PRIMARY KEY,
+                    user_id      TEXT    NOT NULL,
+                    token_hash   TEXT    NOT NULL UNIQUE,
+                    type         TEXT    NOT NULL,
+                    payload      TEXT    NOT NULL DEFAULT '{}',
+                    attempts     INTEGER NOT NULL DEFAULT 0,
+                    max_attempts INTEGER NOT NULL DEFAULT 5,
+                    ip           TEXT    NOT NULL DEFAULT '',
+                    user_agent   TEXT    NOT NULL DEFAULT '',
+                    created_at   TEXT    NOT NULL DEFAULT (datetime('now')),
+                    expires_at   TEXT    NOT NULL,
+                    completed_at TEXT    DEFAULT NULL
+                )
+            ");
+        } else {
+            $this->pdo->exec("
+                CREATE TABLE IF NOT EXISTS auth_challenges (
+                    id           VARCHAR(36)  NOT NULL,
+                    user_id      VARCHAR(255) NOT NULL,
+                    token_hash   CHAR(64)     NOT NULL,
+                    type         VARCHAR(64)  NOT NULL,
+                    payload      JSON         NOT NULL,
+                    attempts     TINYINT      NOT NULL DEFAULT 0,
+                    max_attempts TINYINT      NOT NULL DEFAULT 5,
+                    ip           VARCHAR(45)  NOT NULL DEFAULT '',
+                    user_agent   VARCHAR(512) NOT NULL DEFAULT '',
+                    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    expires_at   DATETIME     NOT NULL,
+                    completed_at DATETIME     DEFAULT NULL,
+                    PRIMARY KEY  (id),
+                    UNIQUE KEY   uq_token_hash (token_hash),
+                    INDEX        idx_user_id   (user_id),
+                    INDEX        idx_expires   (expires_at)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            ");
+        }
+    }
+
+    /**
+     * Hydrate a database row into a ChallengeRecord.
+     *
+     * @param  array<string, mixed> $row
+     * @return ChallengeRecord
+     */
+    private function hydrate(array $row): ChallengeRecord
+    {
+        return new ChallengeRecord(
+            id:          (string) $row['id'],
+            userId:      $row['user_id'],
+            type:        (string) $row['type'],
+            payload:     json_decode((string) $row['payload'], true) ?? [],
+            maxAttempts: (int)    $row['max_attempts'],
+            expiresAt:   new DateTime((string) $row['expires_at']),
+            ip:          (string) $row['ip'],
+            userAgent:   (string) $row['user_agent'],
+            attempts:    (int)    $row['attempts'],
+            completedAt: isset($row['completed_at']) ? new DateTime((string) $row['completed_at']) : null,
+        );
+    }
+}

--- a/src/Challenge/PdoChallengeStorage.php
+++ b/src/Challenge/PdoChallengeStorage.php
@@ -68,11 +68,11 @@ final class PdoChallengeStorage implements ChallengeStorageInterface
     /**
      * @inheritDoc
      */
-    public function complete(ChallengeRecord $record): void
+    public function complete(ChallengeRecord $record, \DateTimeImmutable $now): void
     {
         $this->pdo->prepare(
             'UPDATE auth_challenges SET completed_at = ? WHERE id = ?'
-        )->execute([(new DateTime())->format('Y-m-d H:i:s'), $record->id]);
+        )->execute([$now->format('Y-m-d H:i:s'), $record->id]);
     }
 
     /**
@@ -88,11 +88,11 @@ final class PdoChallengeStorage implements ChallengeStorageInterface
     /**
      * @inheritDoc
      */
-    public function purgeExpired(): void
+    public function purgeExpired(\DateTimeImmutable $now): void
     {
         $this->pdo->prepare(
             'DELETE FROM auth_challenges WHERE expires_at < ?'
-        )->execute([(new DateTime())->format('Y-m-d H:i:s')]);
+        )->execute([$now->format('Y-m-d H:i:s')]);
     }
 
     /**
@@ -120,6 +120,9 @@ final class PdoChallengeStorage implements ChallengeStorageInterface
                     completed_at TEXT    DEFAULT NULL
                 )
             ");
+            $this->pdo->exec('CREATE INDEX IF NOT EXISTS idx_challenges_user_id ON auth_challenges (user_id)');
+            $this->pdo->exec('CREATE INDEX IF NOT EXISTS idx_challenges_expires ON auth_challenges (expires_at)');
+            $this->pdo->exec('CREATE INDEX IF NOT EXISTS idx_challenges_user_type_completed ON auth_challenges (user_id, type, completed_at)');
         } else {
             $this->pdo->exec("
                 CREATE TABLE IF NOT EXISTS auth_challenges (
@@ -138,7 +141,8 @@ final class PdoChallengeStorage implements ChallengeStorageInterface
                     PRIMARY KEY  (id),
                     UNIQUE KEY   uq_token_hash (token_hash),
                     INDEX        idx_user_id   (user_id),
-                    INDEX        idx_expires   (expires_at)
+                    INDEX        idx_expires   (expires_at),
+                    INDEX        idx_user_type_completed (user_id, type, completed_at)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
             ");
         }
@@ -162,7 +166,7 @@ final class PdoChallengeStorage implements ChallengeStorageInterface
             ip:          (string) $row['ip'],
             userAgent:   (string) $row['user_agent'],
             attempts:    (int)    $row['attempts'],
-            completedAt: isset($row['completed_at']) ? new DateTime((string) $row['completed_at']) : null,
+            completedAt: !empty($row['completed_at']) ? new DateTime((string) $row['completed_at']) : null,
         );
     }
 }

--- a/src/Clock/ClockInterface.php
+++ b/src/Clock/ClockInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Clock;
+
+/**
+ * Provides the current time as an immutable value object.
+ *
+ * Compatible with the PSR-20 clock contract — any PSR-20 implementation
+ * satisfies this interface without modification.
+ *
+ * @package AuthKit\Clock
+ */
+interface ClockInterface
+{
+    /**
+     * Return the current time.
+     *
+     * @return \DateTimeImmutable
+     */
+    public function now(): \DateTimeImmutable;
+}

--- a/src/Clock/SystemClock.php
+++ b/src/Clock/SystemClock.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Clock;
+
+/**
+ * System clock — returns the current wall-clock time in the configured timezone.
+ *
+ * @package AuthKit\Clock
+ */
+final class SystemClock implements ClockInterface
+{
+    /**
+     * @var \DateTimeZone
+     */
+    private readonly \DateTimeZone $tz;
+
+    /**
+     * @param \DateTimeZone|string $timezone Timezone for now(). Defaults to UTC.
+     *
+     * @throws \Exception When an invalid timezone string is provided.
+     */
+    public function __construct(\DateTimeZone|string $timezone = 'UTC')
+    {
+        $this->tz = is_string($timezone) ? new \DateTimeZone($timezone) : $timezone;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function now(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('now', $this->tz);
+    }
+}

--- a/src/Credential/CredentialProviderInterface.php
+++ b/src/Credential/CredentialProviderInterface.php
@@ -15,7 +15,8 @@ interface CredentialProviderInterface
      * Verify the supplied credentials.
      *
      * @param  array<string, mixed> $credentials Raw input (e.g. ['email' => ..., 'password' => ...]).
+     * @param  array<string, mixed> $context     Optional request context (e.g. 'ip', 'user_agent') for logging or rate-limiting.
      * @return CredentialResult
      */
-    public function verify(array $credentials): CredentialResult;
+    public function verify(array $credentials, array $context = []): CredentialResult;
 }

--- a/src/Credential/CredentialProviderInterface.php
+++ b/src/Credential/CredentialProviderInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Credential;
+
+/**
+ * Verifies raw credentials and returns the matching user on success.
+ *
+ * @package AuthKit\Credential
+ */
+interface CredentialProviderInterface
+{
+    /**
+     * Verify the supplied credentials.
+     *
+     * @param  array<string, mixed> $credentials Raw input (e.g. ['email' => ..., 'password' => ...]).
+     * @return CredentialResult
+     */
+    public function verify(array $credentials): CredentialResult;
+}

--- a/src/Credential/CredentialResult.php
+++ b/src/Credential/CredentialResult.php
@@ -14,37 +14,41 @@ use AuthKit\User;
 final class CredentialResult
 {
     /**
-     * @param bool      $success Whether credentials were valid.
-     * @param User|null $user    Authenticated user, or null on failure.
-     * @param string    $message Failure reason, or empty string on success.
+     * @param bool                 $success Whether credentials were valid.
+     * @param User|null            $user    Authenticated user, or null on failure.
+     * @param string               $message Failure reason, or empty string on success.
+     * @param array<string, mixed> $meta    Provider-specific metadata (e.g. provider name, JWT claims).
      */
     private function __construct(
         private readonly bool   $success,
         private readonly ?User  $user,
         private readonly string $message,
+        private readonly array  $meta = [],
     ) {
     }
 
     /**
      * Create a successful result with the verified user.
      *
-     * @param  User $user Authenticated user.
+     * @param  User                 $user Authenticated user.
+     * @param  array<string, mixed> $meta Optional provider metadata passed to the login extension pipeline.
      * @return self
      */
-    public static function success(User $user): self
+    public static function success(User $user, array $meta = []): self
     {
-        return new self(true, $user, '');
+        return new self(true, $user, '', $meta);
     }
 
     /**
      * Create a failure result with a reason message.
      *
-     * @param  string $message Human-readable failure reason.
+     * @param  string               $message Human-readable failure reason.
+     * @param  array<string, mixed> $meta    Optional provider metadata (e.g. for audit logging).
      * @return self
      */
-    public static function failure(string $message): self
+    public static function failure(string $message, array $meta = []): self
     {
-        return new self(false, null, $message);
+        return new self(false, null, $message, $meta);
     }
 
     /**
@@ -69,5 +73,24 @@ final class CredentialResult
     public function message(): string
     {
         return $this->message;
+    }
+
+    /**
+     * Return provider metadata or a single key from it.
+     *
+     * With no argument, returns the full metadata array.
+     * With a key, returns that value or $default when not present.
+     *
+     * @param  string|null $key     Key to retrieve, or null for the full array.
+     * @param  mixed       $default Returned when the key is not found.
+     * @return mixed
+     */
+    public function meta(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $this->meta;
+        }
+
+        return $this->meta[$key] ?? $default;
     }
 }

--- a/src/Credential/CredentialResult.php
+++ b/src/Credential/CredentialResult.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Credential;
+
+use AuthKit\User;
+
+/**
+ * Result of a credential verification attempt.
+ *
+ * @package AuthKit\Credential
+ */
+final class CredentialResult
+{
+    /**
+     * @param bool      $success Whether credentials were valid.
+     * @param User|null $user    Authenticated user, or null on failure.
+     * @param string    $message Failure reason, or empty string on success.
+     */
+    private function __construct(
+        private readonly bool   $success,
+        private readonly ?User  $user,
+        private readonly string $message,
+    ) {
+    }
+
+    /**
+     * Create a successful result with the verified user.
+     *
+     * @param  User $user Authenticated user.
+     * @return self
+     */
+    public static function success(User $user): self
+    {
+        return new self(true, $user, '');
+    }
+
+    /**
+     * Create a failure result with a reason message.
+     *
+     * @param  string $message Human-readable failure reason.
+     * @return self
+     */
+    public static function failure(string $message): self
+    {
+        return new self(false, null, $message);
+    }
+
+    /**
+     * @return bool True when credentials were valid.
+     */
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    /**
+     * @return User|null Authenticated user, or null on failure.
+     */
+    public function user(): ?User
+    {
+        return $this->user;
+    }
+
+    /**
+     * @return string Failure reason, or empty string on success.
+     */
+    public function message(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Credential/PdoCredentialProvider.php
+++ b/src/Credential/PdoCredentialProvider.php
@@ -31,8 +31,9 @@ final class PdoCredentialProvider implements CredentialProviderInterface
      * @inheritDoc
      *
      * @param array{email: string, password: string} $credentials
+     * @param array<string, mixed>                   $context     Unused by this provider; available for logging or rate-limiting in custom implementations.
      */
-    public function verify(array $credentials): CredentialResult
+    public function verify(array $credentials, array $context = []): CredentialResult
     {
         $email    = (string) ($credentials['email'] ?? '');
         $password = (string) ($credentials['password'] ?? '');
@@ -43,7 +44,11 @@ final class PdoCredentialProvider implements CredentialProviderInterface
             return CredentialResult::failure('Invalid credentials.');
         }
 
-        $hash = (string) $user->get('password_hash');
+        $hash = $user->get('password_hash');
+
+        if (!is_string($hash) || $hash === '') {
+            return CredentialResult::failure('Local password login is disabled for this account.');
+        }
 
         if (!$this->hasher->verify($password, $hash)) {
             return CredentialResult::failure('Invalid credentials.');
@@ -55,6 +60,6 @@ final class PdoCredentialProvider implements CredentialProviderInterface
             ]);
         }
 
-        return CredentialResult::success($user);
+        return CredentialResult::success($user, ['provider' => 'local', 'method' => 'password']);
     }
 }

--- a/src/Credential/PdoCredentialProvider.php
+++ b/src/Credential/PdoCredentialProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Credential;
+
+use AuthKit\Password\PasswordHasherInterface;
+use AuthKit\Storage\UserStorageInterface;
+
+/**
+ * PDO-backed credential provider for email + password authentication.
+ *
+ * Looks up the user by email, verifies the password via the configured hasher,
+ * and automatically re-hashes the stored password if the hasher signals it is outdated.
+ *
+ * @package AuthKit\Credential
+ */
+final class PdoCredentialProvider implements CredentialProviderInterface
+{
+    /**
+     * @param UserStorageInterface    $storage User persistence layer.
+     * @param PasswordHasherInterface $hasher  Password hashing and verification.
+     */
+    public function __construct(
+        private readonly UserStorageInterface    $storage,
+        private readonly PasswordHasherInterface $hasher,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array{email: string, password: string} $credentials
+     */
+    public function verify(array $credentials): CredentialResult
+    {
+        $email    = (string) ($credentials['email'] ?? '');
+        $password = (string) ($credentials['password'] ?? '');
+
+        $user = $this->storage->findByEmail($email);
+
+        if ($user === null) {
+            return CredentialResult::failure('Invalid credentials.');
+        }
+
+        $hash = (string) $user->get('password_hash');
+
+        if (!$this->hasher->verify($password, $hash)) {
+            return CredentialResult::failure('Invalid credentials.');
+        }
+
+        if ($this->hasher->needsRehash($hash)) {
+            $user = $this->storage->updateUser($user, [
+                'password_hash' => $this->hasher->hash($password),
+            ]);
+        }
+
+        return CredentialResult::success($user);
+    }
+}

--- a/src/Extension/ChallengeExtensionInterface.php
+++ b/src/Extension/ChallengeExtensionInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Extension;
+
+use AuthKit\Challenge\ChallengeRecord;
+use AuthKit\LoginDecision;
+
+/**
+ * Extension that both initiates and handles a specific challenge type.
+ *
+ * When decide() returns LoginDecision::challenge($type), Auth stores a ChallengeRecord
+ * and returns a challenge token to the caller. When the user submits their response,
+ * Auth::completeChallenge() dispatches to the matching ChallengeExtensionInterface.
+ *
+ * Only Auth creates the session — never the extension.
+ *
+ * @package AuthKit\Extension
+ */
+interface ChallengeExtensionInterface extends LoginExtensionInterface
+{
+    /**
+     * Returns true when this extension handles the given challenge type.
+     *
+     * @param  string $type Challenge type identifier (e.g. 'mfa_totp', 'email_activation').
+     * @return bool
+     */
+    public function supportsChallenge(string $type): bool;
+
+    /**
+     * Verify the user's response to a pending challenge.
+     *
+     * Return LoginDecision::allow() to let Auth create the session.
+     * Return LoginDecision::deny(reason) on invalid input — Auth increments the attempt counter.
+     *
+     * @param  ChallengeRecord      $challenge The persisted challenge record.
+     * @param  array<string, mixed> $input     User-supplied verification data (e.g. ['code' => '123456']).
+     * @return LoginDecision allow() or deny(reason).
+     */
+    public function completeChallenge(ChallengeRecord $challenge, array $input): LoginDecision;
+}

--- a/src/Extension/LoginExtensionInterface.php
+++ b/src/Extension/LoginExtensionInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Extension;
+
+use AuthKit\LoginContext;
+use AuthKit\LoginDecision;
+
+/**
+ * Evaluates whether a login attempt should proceed after credentials are verified.
+ *
+ * Extensions are registered via Auth::addLoginExtension() and evaluated in
+ * registration order. The first deny or challenge decision terminates the pipeline.
+ * A session is created only when every registered extension returns allow.
+ *
+ * @package AuthKit\Extension
+ */
+interface LoginExtensionInterface
+{
+    /**
+     * Evaluate the login context and return a decision.
+     *
+     * @param  LoginContext  $context Authenticated user with request metadata.
+     * @return LoginDecision allow(), deny(reason), or challenge(type, payload).
+     */
+    public function decide(LoginContext $context): LoginDecision;
+}

--- a/src/Login.php
+++ b/src/Login.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit;
+
+/**
+ * Immutable result of an Auth::login() call.
+ *
+ * Three possible states:
+ *  - success   : credentials verified, session created, token available.
+ *  - failure   : authentication rejected, message available.
+ *  - challenge : credentials verified but an extension requires an additional
+ *                verification step (MFA, email activation, device check, etc.).
+ *                No session is created until Auth::completeChallenge() succeeds.
+ *
+ * Usage (simple flow):
+ *   $login = $auth->login($email, $password);
+ *   if ($login->isSuccess()) {
+ *       header('Location: /dashboard');
+ *   }
+ *   echo $login->message();
+ *
+ * Usage (challenge flow, e.g. MFA):
+ *   $login = $auth->login($email, $password);
+ *   if ($login->requiresChallenge()) {
+ *       $_SESSION['authkit_challenge'] = $login->challengeToken();
+ *       header('Location: /login/challenge/' . $login->challengeType());
+ *   }
+ *
+ * @package AuthKit
+ */
+final class Login
+{
+    private const STATUS_SUCCESS   = 'success';
+    private const STATUS_FAILURE   = 'failure';
+    private const STATUS_CHALLENGE = 'challenge';
+
+    private function __construct(
+        private readonly string  $status,
+        private readonly string  $message,
+        private readonly ?string $token          = null,
+        private readonly ?User   $user           = null,
+        private readonly ?string $challengeToken = null,
+        private readonly ?string $challengeType  = null,
+    ) {
+    }
+
+    /**
+     * Create a successful login result with a session token.
+     *
+     * @param string $token Session token stored in DB and $_SESSION.
+     * @param User   $user  Authenticated user.
+     * @return self
+     */
+    public static function success(string $token, User $user): self
+    {
+        return new self(
+            status:  self::STATUS_SUCCESS,
+            message: '',
+            token:   $token,
+            user:    $user,
+        );
+    }
+
+    /**
+     * Create a failure result.
+     *
+     * @param string $message Human-readable reason shown to the user.
+     * @return self
+     */
+    public static function failure(string $message): self
+    {
+        return new self(
+            status:  self::STATUS_FAILURE,
+            message: $message,
+        );
+    }
+
+    /**
+     * Create a challenge-required result.
+     *
+     * Credentials were verified but an extension blocked session creation
+     * pending an additional step. No session exists at this point.
+     *
+     * @param string $challengeToken Raw token to pass to Auth::completeChallenge().
+     *                               Store on the caller side (e.g. $_SESSION['authkit_challenge']).
+     * @param string $challengeType  Extension-defined type identifier (e.g. 'mfa_totp', 'email_activation').
+     * @param User   $user           Pre-session user — credentials verified, no session yet.
+     * @return self
+     */
+    public static function challengeRequired(string $challengeToken, string $challengeType, User $user): self
+    {
+        return new self(
+            status:         self::STATUS_CHALLENGE,
+            message:        '',
+            user:           $user,
+            challengeToken: $challengeToken,
+            challengeType:  $challengeType,
+        );
+    }
+
+    /**
+     * @return bool True when a session was created and token() is available.
+     */
+    public function isSuccess(): bool
+    {
+        return $this->status === self::STATUS_SUCCESS;
+    }
+
+    /**
+     * @return bool True when an additional verification step is required.
+     */
+    public function requiresChallenge(): bool
+    {
+        return $this->status === self::STATUS_CHALLENGE;
+    }
+
+    /**
+     * @return bool True when authentication was rejected.
+     */
+    public function isFailure(): bool
+    {
+        return $this->status === self::STATUS_FAILURE;
+    }
+
+    /**
+     * @return string|null Session token (set only when isSuccess() is true).
+     */
+    public function token(): ?string
+    {
+        return $this->token;
+    }
+
+    /**
+     * @return User|null Authenticated user (null on failure).
+     */
+    public function user(): ?User
+    {
+        return $this->user;
+    }
+
+    /**
+     * @return string|null Raw token to pass to completeChallenge() (set only when requiresChallenge()).
+     */
+    public function challengeToken(): ?string
+    {
+        return $this->challengeToken;
+    }
+
+    /**
+     * @return string|null Challenge type identifier (set only when requiresChallenge()).
+     */
+    public function challengeType(): ?string
+    {
+        return $this->challengeType;
+    }
+
+    /**
+     * @return string Error or informational message (meaningful when isFailure() or requiresChallenge()).
+     */
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return string Raw status string ('success', 'failure', 'challenge').
+     */
+    public function status(): string
+    {
+        return $this->status;
+    }
+}

--- a/src/Login.php
+++ b/src/Login.php
@@ -83,17 +83,18 @@ final class Login
      * Credentials were verified but an extension blocked session creation
      * pending an additional step. No session exists at this point.
      *
-     * @param string $challengeToken Raw token to pass to Auth::completeChallenge().
-     *                               Store on the caller side (e.g. $_SESSION['authkit_challenge']).
-     * @param string $challengeType  Extension-defined type identifier (e.g. 'mfa_totp', 'email_activation').
-     * @param User   $user           Pre-session user — credentials verified, no session yet.
+     * @param string      $challengeToken Raw token to pass to Auth::completeChallenge().
+     *                                    Store on the caller side (e.g. $_SESSION['authkit_challenge']).
+     * @param string      $challengeType  Extension-defined type identifier (e.g. 'mfa_totp', 'email_activation').
+     * @param User        $user           Pre-session user — credentials verified, no session yet.
+     * @param string|null $message        Optional informational message (e.g. 'A code was sent to your email.').
      * @return self
      */
-    public static function challengeRequired(string $challengeToken, string $challengeType, User $user): self
+    public static function challengeRequired(string $challengeToken, string $challengeType, User $user, ?string $message = null): self
     {
         return new self(
             status:         self::STATUS_CHALLENGE,
-            message:        '',
+            message:        $message ?? '',
             user:           $user,
             challengeToken: $challengeToken,
             challengeType:  $challengeType,

--- a/src/LoginContext.php
+++ b/src/LoginContext.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit;
+
+/**
+ * Immutable context passed to every LoginExtensionInterface::decide() call.
+ *
+ * Built after successful credential verification, before session creation.
+ * Contains everything an extension needs to make its allow/deny/challenge decision.
+ *
+ * @package AuthKit
+ */
+final class LoginContext
+{
+    /**
+     * @param User                 $user      Authenticated user (credentials verified, no session yet).
+     * @param string               $ip        Client IP address from the request.
+     * @param string               $userAgent Client User-Agent header value.
+     * @param array<string, mixed> $meta      Optional extra data set by the credential provider or caller.
+     */
+    public function __construct(
+        public readonly User   $user,
+        public readonly string $ip,
+        public readonly string $userAgent,
+        public readonly array  $meta = [],
+    ) {
+    }
+}

--- a/src/LoginContext.php
+++ b/src/LoginContext.php
@@ -15,16 +15,38 @@ namespace AuthKit;
 final class LoginContext
 {
     /**
-     * @param User                 $user      Authenticated user (credentials verified, no session yet).
-     * @param string               $ip        Client IP address from the request.
-     * @param string               $userAgent Client User-Agent header value.
-     * @param array<string, mixed> $meta      Optional extra data set by the credential provider or caller.
+     * @param User                 $user           Authenticated user (credentials verified, no session yet).
+     * @param string               $ip             Client IP address from the request.
+     * @param string               $userAgent      Client User-Agent header value.
+     * @param array<string, mixed> $credentialMeta Provider-specific metadata from CredentialResult (e.g. provider name, JWT claims).
      */
     public function __construct(
         public readonly User   $user,
-        public readonly string $ip,
-        public readonly string $userAgent,
-        public readonly array  $meta = [],
+        public readonly string $ip             = '',
+        public readonly string $userAgent      = '',
+        public readonly array  $credentialMeta = [],
     ) {
+    }
+
+    /**
+     * Return a single value from credential metadata by key.
+     *
+     * @param  string $key
+     * @param  mixed  $default Returned when the key is not found.
+     * @return mixed
+     */
+    public function credential(string $key, mixed $default = null): mixed
+    {
+        return $this->credentialMeta[$key] ?? $default;
+    }
+
+    /**
+     * Return all credential metadata from the provider.
+     *
+     * @return array<string, mixed>
+     */
+    public function credentials(): array
+    {
+        return $this->credentialMeta;
     }
 }

--- a/src/LoginDecision.php
+++ b/src/LoginDecision.php
@@ -21,10 +21,13 @@ final class LoginDecision
     private const CHALLENGE = 'challenge';
 
     private function __construct(
-        private readonly string  $status,
-        private readonly ?string $reason           = null,
-        private readonly ?string $challengeType    = null,
-        private readonly array   $challengePayload = [],
+        private readonly string              $status,
+        private readonly ?string             $reason              = null,
+        private readonly ?string             $challengeType       = null,
+        private readonly array               $challengePayload    = [],
+        private readonly ?string             $challengeMessage    = null,
+        private readonly ?\DateTimeInterface $challengeExpiresAt  = null,
+        private readonly ?int                $challengeMaxAttempts = null,
     ) {
     }
 
@@ -52,14 +55,29 @@ final class LoginDecision
     /**
      * Require an additional verification step before session creation.
      *
-     * @param string               $type    Challenge type handled by a ChallengeExtensionInterface.
-     *                                      Examples: 'mfa_totp', 'email_activation', 'new_device'.
-     * @param array<string, mixed> $payload Data stored with the challenge record (e.g. hashed OTP code).
+     * @param string                   $type        Challenge type handled by a ChallengeExtensionInterface.
+     *                                              Examples: 'mfa_totp', 'email_activation', 'new_device'.
+     * @param array<string, mixed>     $payload     Data stored with the challenge record (e.g. hashed OTP code).
+     * @param string|null              $message     Optional message returned to the caller (e.g. 'A code was sent to your email.').
+     * @param \DateTimeInterface|null  $expiresAt   Override default challenge TTL. Defaults to 15 minutes.
+     * @param int|null                 $maxAttempts Override default max verification attempts. Defaults to 5.
      * @return self
      */
-    public static function challenge(string $type, array $payload = []): self
-    {
-        return new self(self::CHALLENGE, challengeType: $type, challengePayload: $payload);
+    public static function challenge(
+        string              $type,
+        array               $payload     = [],
+        ?string             $message     = null,
+        ?\DateTimeInterface $expiresAt   = null,
+        ?int                $maxAttempts = null,
+    ): self {
+        return new self(
+            self::CHALLENGE,
+            challengeType:        $type,
+            challengePayload:     $payload,
+            challengeMessage:     $message,
+            challengeExpiresAt:   $expiresAt,
+            challengeMaxAttempts: $maxAttempts,
+        );
     }
 
     /**
@@ -108,6 +126,30 @@ final class LoginDecision
     public function challengePayload(): array
     {
         return $this->challengePayload;
+    }
+
+    /**
+     * @return string|null Optional message for the caller when a challenge is required.
+     */
+    public function challengeMessage(): ?string
+    {
+        return $this->challengeMessage;
+    }
+
+    /**
+     * @return \DateTimeInterface|null Custom challenge expiry, or null to use the default (15 minutes).
+     */
+    public function challengeExpiresAt(): ?\DateTimeInterface
+    {
+        return $this->challengeExpiresAt;
+    }
+
+    /**
+     * @return int|null Custom max attempts, or null to use the default (5).
+     */
+    public function challengeMaxAttempts(): ?int
+    {
+        return $this->challengeMaxAttempts;
     }
 
     /**

--- a/src/LoginDecision.php
+++ b/src/LoginDecision.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit;
+
+/**
+ * Immutable decision returned by LoginExtensionInterface::decide().
+ *
+ * Three possible states:
+ *  - allow     : this extension permits the login pipeline to continue.
+ *  - deny      : this extension blocks login; session will NOT be created.
+ *  - challenge : an additional verification step is required before session creation.
+ *
+ * @package AuthKit
+ */
+final class LoginDecision
+{
+    private const ALLOW     = 'allow';
+    private const DENY      = 'deny';
+    private const CHALLENGE = 'challenge';
+
+    private function __construct(
+        private readonly string  $status,
+        private readonly ?string $reason           = null,
+        private readonly ?string $challengeType    = null,
+        private readonly array   $challengePayload = [],
+    ) {
+    }
+
+    /**
+     * Allow the login pipeline to proceed to the next extension or session creation.
+     *
+     * @return self
+     */
+    public static function allow(): self
+    {
+        return new self(self::ALLOW);
+    }
+
+    /**
+     * Block login with a human-readable reason.
+     *
+     * @param string $reason Error message returned to the caller (e.g. 'Account suspended.').
+     * @return self
+     */
+    public static function deny(string $reason): self
+    {
+        return new self(self::DENY, reason: $reason);
+    }
+
+    /**
+     * Require an additional verification step before session creation.
+     *
+     * @param string               $type    Challenge type handled by a ChallengeExtensionInterface.
+     *                                      Examples: 'mfa_totp', 'email_activation', 'new_device'.
+     * @param array<string, mixed> $payload Data stored with the challenge record (e.g. hashed OTP code).
+     * @return self
+     */
+    public static function challenge(string $type, array $payload = []): self
+    {
+        return new self(self::CHALLENGE, challengeType: $type, challengePayload: $payload);
+    }
+
+    /**
+     * @return bool True when this decision allows the pipeline to continue.
+     */
+    public function isAllow(): bool
+    {
+        return $this->status === self::ALLOW;
+    }
+
+    /**
+     * @return bool True when this decision blocks login.
+     */
+    public function isDeny(): bool
+    {
+        return $this->status === self::DENY;
+    }
+
+    /**
+     * @return bool True when this decision requires a challenge step.
+     */
+    public function isChallenge(): bool
+    {
+        return $this->status === self::CHALLENGE;
+    }
+
+    /**
+     * @return string|null Denial reason (set only when isDeny() is true).
+     */
+    public function reason(): ?string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * @return string|null Challenge type identifier (set only when isChallenge() is true).
+     */
+    public function challengeType(): ?string
+    {
+        return $this->challengeType;
+    }
+
+    /**
+     * @return array<string, mixed> Challenge payload stored in the challenge record.
+     */
+    public function challengePayload(): array
+    {
+        return $this->challengePayload;
+    }
+
+    /**
+     * @return string Raw status string ('allow', 'deny', 'challenge').
+     */
+    public function status(): string
+    {
+        return $this->status;
+    }
+}

--- a/src/Password/NativePasswordHasher.php
+++ b/src/Password/NativePasswordHasher.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Password;
+
+/**
+ * Password hasher backed by PHP's native password_* functions.
+ *
+ * @package AuthKit\Password
+ */
+final class NativePasswordHasher implements PasswordHasherInterface
+{
+    /**
+     * @param int|string $algorithm Algorithm constant passed to password_hash() (default: PASSWORD_DEFAULT).
+     */
+    public function __construct(
+        private readonly int|string $algorithm = PASSWORD_DEFAULT,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hash(string $plain): string
+    {
+        return password_hash($plain, $this->algorithm);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function verify(string $plain, string $hash): bool
+    {
+        return password_verify($plain, $hash);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function needsRehash(string $hash): bool
+    {
+        return password_needs_rehash($hash, $this->algorithm);
+    }
+}

--- a/src/Password/PasswordHasherInterface.php
+++ b/src/Password/PasswordHasherInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Password;
+
+/**
+ * Hashes and verifies passwords for storage and authentication.
+ *
+ * @package AuthKit\Password
+ */
+interface PasswordHasherInterface
+{
+    /**
+     * Hash a plain-text password for storage.
+     *
+     * @param  string $plain Plain-text password.
+     * @return string Hashed password.
+     */
+    public function hash(string $plain): string;
+
+    /**
+     * Verify a plain-text password against a stored hash.
+     *
+     * @param  string $plain Plain-text password.
+     * @param  string $hash  Stored hash to verify against.
+     * @return bool True when the password matches the hash.
+     */
+    public function verify(string $plain, string $hash): bool;
+
+    /**
+     * Check whether an existing hash should be upgraded.
+     *
+     * @param  string $hash Stored hash to inspect.
+     * @return bool True when the hash should be re-hashed on next login.
+     */
+    public function needsRehash(string $hash): bool;
+}

--- a/src/Storage/PdoUserStorage.php
+++ b/src/Storage/PdoUserStorage.php
@@ -1,164 +1,103 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AuthKit\Storage;
 
-use PDO;
-use DateTime;
 use AuthKit\User;
-use AuthKit\Storage\UserStorageInterface;
+use AuthKit\UserId\NullUserIdPolicy;
+use AuthKit\UserId\UserIdPolicyInterface;
+use DateTime;
+use PDO;
 
-class PdoUserStorage implements UserStorageInterface
+/**
+ * PDO-backed user storage supporting MySQL/MariaDB and SQLite.
+ *
+ * @package AuthKit\Storage
+ */
+final class PdoUserStorage implements UserStorageInterface
 {
-    private PDO $pdo;
-
-
     /**
-     * PdoUserStorage constructor.
-     *
-     * @param PDO $pdo PDO instance connected to the database.
+     * @param PDO                  $pdo          Database connection.
+     * @param UserIdPolicyInterface $userIdPolicy ID generation policy (default: database auto-increment).
      */
-    public function __construct(PDO $pdo)
-    {
-        $this->pdo = $pdo;
+    public function __construct(
+        private readonly PDO                  $pdo,
+        private readonly UserIdPolicyInterface $userIdPolicy = new NullUserIdPolicy(),
+    ) {
     }
 
     /**
-     * Find a user by their email address.
-     *
-     * @param string $email The email address to search for.
-     * @return User|null Returns a User object if found, or null if not found.
+     * @inheritDoc
      */
     public function findByEmail(string $email): ?User
     {
-        $stmt = $this->pdo->prepare("SELECT * FROM users WHERE email = :email LIMIT 1");
+        $stmt = $this->pdo->prepare('SELECT * FROM users WHERE email = :email LIMIT 1');
         $stmt->execute(['email' => $email]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if (!$row) return null;
-
-        return new User($row);
+        return $row ? new User($row) : null;
     }
 
     /**
-     * Find a user by their session token.
-     *
-     * @param string $token The session token to search for.
-     * @return User|null Returns a User object if found, or null if not found.
+     * @inheritDoc
      */
     public function findByToken(string $token): ?User
     {
-        $stmt = $this->pdo->prepare("
+        $stmt = $this->pdo->prepare('
             SELECT u.* FROM users u
             JOIN sessions s ON s.user_id = u.id
-            WHERE s.token = :token AND s.expires_at > NOW()
+            WHERE s.token = :token
+              AND (s.expires_at IS NULL OR s.expires_at > :now)
             LIMIT 1
-        ");
-        $stmt->execute(['token' => $token]);
+        ');
+        $stmt->execute([
+            'token' => $token,
+            'now'   => (new DateTime())->format('Y-m-d H:i:s'),
+        ]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if (!$row) return null;
-
-        return new User($row);
+        return $row ? new User($row) : null;
     }
 
     /**
-     * Find a user by their ID.
-     *
-     * @param int $id The user ID to search for.
-     * @return User|null Returns a User object if found, or null if not found.
+     * @inheritDoc
      */
-    public function findById($id): ?User
+    public function findById(int|string $id): ?User
     {
-        $stmt = $this->pdo->prepare("SELECT * FROM users WHERE id = :id LIMIT 1");
+        $stmt = $this->pdo->prepare('SELECT * FROM users WHERE id = :id LIMIT 1');
         $stmt->execute(['id' => $id]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if (!$row) return null;
-
-        return new User($row);
+        return $row ? new User($row) : null;
     }
 
     /**
-     * Create a new user in the database.
-     *
-     * @param string $email The email address of the user.
-     * @param string $passwordHash The hashed password of the user.
-     * @param array $fields Additional fields to store in the user record.
-     * @return User Returns the created User object.
+     * @inheritDoc
      */
     public function createUser(string $email, string $passwordHash, array $fields = []): User
     {
-        $allFields = array_merge([
-            'email' => $email,
-            'password_hash' => $passwordHash,
-        ], $fields);
+        $generatedId = $this->userIdPolicy->generate();
 
-        $columns = implode(', ', array_map(fn($key) => "`$key`", array_keys($allFields)));
-        $placeholders = implode(', ', array_map(fn($key) => ":$key", array_keys($allFields)));
+        $allFields = array_merge(
+            $generatedId !== null ? ['id' => $generatedId] : [],
+            ['email' => $email, 'password_hash' => $passwordHash],
+            $fields,
+        );
+
+        $columns      = implode(', ', array_map(fn($k) => "`$k`", array_keys($allFields)));
+        $placeholders = implode(', ', array_map(fn($k) => ":$k", array_keys($allFields)));
 
         $stmt = $this->pdo->prepare("INSERT INTO users ($columns) VALUES ($placeholders)");
         $stmt->execute($allFields);
 
-        $id = (int) $this->pdo->lastInsertId();
-        $allFields['id'] = $id;
+        $allFields['id'] = $generatedId ?? $this->pdo->lastInsertId();
 
         return new User($allFields);
     }
 
     /**
-     * Store a session token for a user.
-     *
-     * @param User $user The user to associate the token with.
-     * @param string $token The session token to store.
-     * @param DateTime|null $expiresAt Optional expiration date for the token.
-     */
-    public function storeToken(User $user, string $token, ?\DateTime $expiresAt): void
-    {
-        $stmt = $this->pdo->prepare("INSERT INTO sessions (user_id, token, expires_at) VALUES (:uid, :token, :exp)");
-        $stmt->execute([
-            'uid' => $user->getId(),
-            'token' => $token,
-            'exp' => $expiresAt ? $expiresAt->format('Y-m-d H:i:s') : null,
-        ]);
-    }
-
-    /**
-     * Delete a session token from the database.
-     *
-     * @param string $token The session token to delete.
-     * @return int The number of tokens that were deleted (mostly 0/1).
-     */
-    public function deleteToken(string $token): int
-    {
-        $stmt = $this->pdo->prepare("DELETE FROM sessions WHERE token = :token");
-        $stmt->execute(['token' => $token]);
-        return $stmt->rowCount();
-    }
-
-    /**
-     * Delete all session tokens belonging to a specific user.
-     *
-     * This method invalidates all active sessions for the given user ID by
-     * removing corresponding records from the `sessions` table.
-     * Typically used for administrative or security actions (e.g. force logout).
-     *
-     * @param int $userId The ID of the user whose sessions should be deleted.
-     *
-     * @return int The number of sessions that were removed.
-     */
-    public function deleteTokensByUserId(int $userId): int
-    {
-        $stmt = $this->pdo->prepare("DELETE FROM sessions WHERE user_id = :uid");
-        $stmt->execute(['uid' => $userId]);
-        return $stmt->rowCount();
-    }
-
-    /**
-     * Update a user's information in the database.
-     *
-     * @param User $user The user to update.
-     * @param array $fields Associative array of fields to update.
-     * @return User Returns the updated User object.
+     * @inheritDoc
      */
     public function updateUser(User $user, array $fields): User
     {
@@ -167,69 +106,121 @@ class PdoUserStorage implements UserStorageInterface
         }
 
         $updates = [];
-        $params = [];
+        $params  = [];
 
         foreach ($fields as $key => $value) {
-            $updates[] = "`$key` = :$key";
+            $updates[]       = "`$key` = :$key";
             $params[":$key"] = $value;
         }
 
-        $params[":id"] = $user->getId();
-        $sql = "UPDATE users SET " . implode(", ", $updates) . " WHERE id = :id";
-        $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
+        $params[':id'] = $user->getId();
 
-        return $this->findByEmail($fields['email'] ?? $user->getEmail());
+        $this->pdo->prepare('UPDATE users SET ' . implode(', ', $updates) . ' WHERE id = :id')
+            ->execute($params);
+
+        $id = $user->getId();
+
+        return $id !== null ? ($this->findById($id) ?? $user) : $user;
     }
 
     /**
-     * Purge expired session tokens from the database.
+     * @inheritDoc
      */
-    public function purgeExpiredTokens(): void
+    public function storeToken(User $user, string $token, ?\DateTime $expiresAt): void
     {
-        $this->pdo->prepare("
-        DELETE FROM sessions 
-        WHERE expires_at IS NOT NULL AND expires_at < :now
-    ")->execute([
-            'now' => (new \DateTime())->format('Y-m-d H:i:s'),
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO sessions (user_id, token, expires_at) VALUES (:uid, :token, :exp)'
+        );
+        $stmt->execute([
+            'uid'   => $user->getId(),
+            'token' => $token,
+            'exp'   => $expiresAt?->format('Y-m-d H:i:s'),
         ]);
     }
 
     /**
-     * Create the necessary database schema for user and session management.
+     * @inheritDoc
+     */
+    public function deleteToken(string $token): int
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM sessions WHERE token = :token');
+        $stmt->execute(['token' => $token]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteTokensByUserId(int|string $userId): int
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM sessions WHERE user_id = :uid');
+        $stmt->execute(['uid' => $userId]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Delete all expired session tokens.
      *
-     * This method creates the `users` and `sessions` tables if they do not already exist.
-     * It also sets up foreign key constraints and enables foreign key support for SQLite.
+     * @return void
+     */
+    public function purgeExpiredTokens(): void
+    {
+        $this->pdo->prepare(
+            'DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at < :now'
+        )->execute(['now' => (new DateTime())->format('Y-m-d H:i:s')]);
+    }
+
+    /**
+     * @inheritDoc
      */
     public function createSchema(): void
     {
         $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
 
-        $types = $driver === 'mysql'
-            ? ['id' => 'INT AUTO_INCREMENT PRIMARY KEY', 'text' => 'VARCHAR(255)', 'datetime' => 'DATETIME']
-            : ['id' => 'INTEGER PRIMARY KEY AUTOINCREMENT', 'text' => 'TEXT', 'datetime' => 'TEXT'];
-
         if ($driver === 'sqlite') {
-            $this->pdo->exec("PRAGMA foreign_keys = ON;");
+            $this->pdo->exec('PRAGMA foreign_keys = ON;');
+            $this->pdo->exec("
+                CREATE TABLE IF NOT EXISTS users (
+                    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email         TEXT    NOT NULL UNIQUE,
+                    password_hash TEXT    NOT NULL,
+                    active        INTEGER NOT NULL DEFAULT 0
+                )
+            ");
+            $this->pdo->exec("
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id    INTEGER NOT NULL,
+                    token      TEXT    NOT NULL UNIQUE,
+                    expires_at TEXT    DEFAULT NULL,
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                )
+            ");
+        } else {
+            $this->pdo->exec("
+                CREATE TABLE IF NOT EXISTS users (
+                    id            INT          NOT NULL AUTO_INCREMENT,
+                    email         VARCHAR(255) NOT NULL,
+                    password_hash VARCHAR(255) NOT NULL,
+                    active        TINYINT      NOT NULL DEFAULT 0,
+                    PRIMARY KEY (id),
+                    UNIQUE KEY uq_email (email)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            ");
+            $this->pdo->exec("
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id         INT          NOT NULL AUTO_INCREMENT,
+                    user_id    INT          NOT NULL,
+                    token      VARCHAR(255) NOT NULL,
+                    expires_at DATETIME     DEFAULT NULL,
+                    PRIMARY KEY (id),
+                    UNIQUE KEY uq_token (token),
+                    INDEX      idx_user_id (user_id),
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            ");
         }
-
-        $this->pdo->exec("
-		    CREATE TABLE IF NOT EXISTS users (
-		        id {$types['id']},
-		        email {$types['text']} NOT NULL UNIQUE,
-		        password_hash {$types['text']} NOT NULL,
-		        active INTEGER DEFAULT 0
-		    );
-		");
-
-        $this->pdo->exec("
-		    CREATE TABLE IF NOT EXISTS sessions (
-		        id {$types['id']},
-		        user_id INTEGER NOT NULL,
-		        token {$types['text']} NOT NULL UNIQUE,
-		        expires_at {$types['datetime']},
-		        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
-		    );
-		");
     }
 }

--- a/src/Storage/PdoUserStorage.php
+++ b/src/Storage/PdoUserStorage.php
@@ -7,7 +7,6 @@ namespace AuthKit\Storage;
 use AuthKit\User;
 use AuthKit\UserId\NullUserIdPolicy;
 use AuthKit\UserId\UserIdPolicyInterface;
-use DateTime;
 use PDO;
 
 /**
@@ -22,7 +21,7 @@ final class PdoUserStorage implements UserStorageInterface
      * @param UserIdPolicyInterface $userIdPolicy ID generation policy (default: database auto-increment).
      */
     public function __construct(
-        private readonly PDO                  $pdo,
+        private readonly PDO                   $pdo,
         private readonly UserIdPolicyInterface $userIdPolicy = new NullUserIdPolicy(),
     ) {
     }
@@ -42,7 +41,7 @@ final class PdoUserStorage implements UserStorageInterface
     /**
      * @inheritDoc
      */
-    public function findByToken(string $token): ?User
+    public function findByToken(string $token, \DateTimeImmutable $now): ?User
     {
         $stmt = $this->pdo->prepare('
             SELECT u.* FROM users u
@@ -53,7 +52,7 @@ final class PdoUserStorage implements UserStorageInterface
         ');
         $stmt->execute([
             'token' => $token,
-            'now'   => (new DateTime())->format('Y-m-d H:i:s'),
+            'now'   => $now->format('Y-m-d H:i:s'),
         ]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -126,7 +125,7 @@ final class PdoUserStorage implements UserStorageInterface
     /**
      * @inheritDoc
      */
-    public function storeToken(User $user, string $token, ?\DateTime $expiresAt): void
+    public function storeToken(User $user, string $token, ?\DateTimeInterface $expiresAt): void
     {
         $stmt = $this->pdo->prepare(
             'INSERT INTO sessions (user_id, token, expires_at) VALUES (:uid, :token, :exp)'
@@ -163,13 +162,18 @@ final class PdoUserStorage implements UserStorageInterface
     /**
      * Delete all expired session tokens.
      *
+     * Typically called from a maintenance job or cron — not part of the login flow.
+     * The caller is responsible for supplying the reference time to ensure
+     * timezone-consistent comparisons against the stored expires_at column.
+     *
+     * @param  \DateTimeImmutable $now Sessions with expires_at before this value will be deleted.
      * @return void
      */
-    public function purgeExpiredTokens(): void
+    public function purgeExpiredTokens(\DateTimeImmutable $now): void
     {
         $this->pdo->prepare(
             'DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at < :now'
-        )->execute(['now' => (new DateTime())->format('Y-m-d H:i:s')]);
+        )->execute(['now' => $now->format('Y-m-d H:i:s')]);
     }
 
     /**
@@ -185,7 +189,7 @@ final class PdoUserStorage implements UserStorageInterface
                 CREATE TABLE IF NOT EXISTS users (
                     id            INTEGER PRIMARY KEY AUTOINCREMENT,
                     email         TEXT    NOT NULL UNIQUE,
-                    password_hash TEXT    NOT NULL,
+                    password_hash TEXT    NULL,
                     active        INTEGER NOT NULL DEFAULT 0
                 )
             ");
@@ -203,7 +207,7 @@ final class PdoUserStorage implements UserStorageInterface
                 CREATE TABLE IF NOT EXISTS users (
                     id            INT          NOT NULL AUTO_INCREMENT,
                     email         VARCHAR(255) NOT NULL,
-                    password_hash VARCHAR(255) NOT NULL,
+                    password_hash VARCHAR(255) NULL,
                     active        TINYINT      NOT NULL DEFAULT 0,
                     PRIMARY KEY (id),
                     UNIQUE KEY uq_email (email)

--- a/src/Storage/UserStorageInterface.php
+++ b/src/Storage/UserStorageInterface.php
@@ -1,80 +1,91 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AuthKit\Storage;
 
 use AuthKit\User;
 
-
+/**
+ * Persists and retrieves user records and session tokens.
+ *
+ * @package AuthKit\Storage
+ */
 interface UserStorageInterface
 {
     /**
      * Find a user by their email address.
      *
-     * @param string $email The email address to search for.
-     * @return User|null Returns a User object if found, or null if not found.
+     * @param  string $email The email address to search for.
+     * @return User|null
      */
     public function findByEmail(string $email): ?User;
 
     /**
      * Find a user by their session token.
      *
-     * @param string $token The session token to search for.
-     * @return User|null Returns a User object if found, or null if not found.
+     * @param  string $token The session token to search for.
+     * @return User|null
      */
     public function findByToken(string $token): ?User;
 
     /**
      * Find a user by their ID.
      *
-     * @param int $id The user ID to search for.
-     * @return User|null Returns a User object if found, or null if not found.
+     * @param  int|string $id The user ID to search for.
+     * @return User|null
+     */
+    public function findById(int|string $id): ?User;
+
+    /**
+     * Create and persist a new user.
+     *
+     * @param  string               $email        User's email address.
+     * @param  string               $passwordHash Hashed password.
+     * @param  array<string, mixed> $fields       Additional fields to store.
+     * @return User
      */
     public function createUser(string $email, string $passwordHash, array $fields = []): User;
 
     /**
-     * Update an existing user.
+     * Update fields on an existing user.
      *
-     * @param User $user The user object to update.
-     * @param array $fields Associative array of fields to update.
-     * @return User Returns the updated User object.
+     * @param  User                 $user   The user to update.
+     * @param  array<string, mixed> $fields Associative array of fields to update.
+     * @return User Updated user.
      */
     public function updateUser(User $user, array $fields): User;
 
     /**
      * Store a session token for a user.
      *
-     * @param User $user The user object.
-     * @param string $token The session token to store.
-     * @param \DateTime|null $expiresAt Optional expiration date/time for the token.
+     * @param  User           $user      The user to associate the token with.
+     * @param  string         $token     The session token to store.
+     * @param  \DateTime|null $expiresAt Optional expiration date/time.
+     * @return void
      */
     public function storeToken(User $user, string $token, ?\DateTime $expiresAt): void;
 
     /**
-     * Delete a session token.
+     * Delete a single session token.
      *
-     * @param string $token The session token to delete.
-     * @return int The number of tokens that were deleted (mostly 0/1).
+     * @param  string $token The session token to delete.
+     * @return int Number of tokens deleted (0 or 1).
      */
     public function deleteToken(string $token): int;
 
     /**
-     * Delete all session tokens for given user id.
-     * @return int number of removed tokens.
+     * Delete all session tokens for a given user.
+     *
+     * @param  int|string $userId The user ID whose tokens should be removed.
+     * @return int Number of tokens deleted.
      */
-    public function deleteTokensByUserId(int $userId): int;
+    public function deleteTokensByUserId(int|string $userId): int;
 
     /**
      * Create the necessary database schema for user storage.
      *
-     * This method should be called to initialize the storage system.
+     * @return void
      */
     public function createSchema(): void;
-
-    /**
-     * Find a user by their ID.
-     *
-     * @param int $id The user ID to search for.
-     * @return User|null Returns a User object if found, or null if not found.
-     */
-    public function findById($id): ?User;
 }

--- a/src/Storage/UserStorageInterface.php
+++ b/src/Storage/UserStorageInterface.php
@@ -24,10 +24,15 @@ interface UserStorageInterface
     /**
      * Find a user by their session token.
      *
-     * @param  string $token The session token to search for.
+     * $now is used to filter out expired sessions at the query level.
+     * Pass the current time from your clock to ensure timezone-consistent
+     * expiry comparisons against the stored expires_at column.
+     *
+     * @param  string            $token The session token to search for.
+     * @param  \DateTimeImmutable $now   Current time used to filter expired sessions.
      * @return User|null
      */
-    public function findByToken(string $token): ?User;
+    public function findByToken(string $token, \DateTimeImmutable $now): ?User;
 
     /**
      * Find a user by their ID.
@@ -59,12 +64,12 @@ interface UserStorageInterface
     /**
      * Store a session token for a user.
      *
-     * @param  User           $user      The user to associate the token with.
-     * @param  string         $token     The session token to store.
-     * @param  \DateTime|null $expiresAt Optional expiration date/time.
+     * @param  User                   $user      The user to associate the token with.
+     * @param  string                 $token     The session token to store.
+     * @param  \DateTimeInterface|null $expiresAt Optional expiration date/time.
      * @return void
      */
-    public function storeToken(User $user, string $token, ?\DateTime $expiresAt): void;
+    public function storeToken(User $user, string $token, ?\DateTimeInterface $expiresAt): void;
 
     /**
      * Delete a single session token.

--- a/src/Transport/BearerHeaderTransport.php
+++ b/src/Transport/BearerHeaderTransport.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Transport;
+
+/**
+ * Token transport for stateless API clients using HTTP Bearer authentication.
+ *
+ * Reads the token from the Authorization: Bearer <token> request header.
+ * set() and clear() are no-ops — the client is responsible for storing
+ * and discarding the token on its own side.
+ *
+ * @package AuthKit\Transport
+ */
+final class BearerHeaderTransport implements TokenTransportInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Extracts the token from the Authorization: Bearer <token> header.
+     */
+    public function get(): ?string
+    {
+        $header = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+
+        if (!str_starts_with($header, 'Bearer ')) {
+            return null;
+        }
+
+        $token = substr($header, 7);
+
+        return $token !== '' ? $token : null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * No-op — the client stores the token on its own side.
+     */
+    public function set(string $token): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * No-op — the client discards the token on its own side.
+     */
+    public function clear(): void
+    {
+    }
+}

--- a/src/Transport/PhpSessionTransport.php
+++ b/src/Transport/PhpSessionTransport.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Transport;
+
+/**
+ * Token transport backed by the native PHP session.
+ *
+ * This is the default transport for web applications. The token is stored
+ * under a configurable key in $_SESSION and travels via session cookie.
+ *
+ * @package AuthKit\Transport
+ */
+final class PhpSessionTransport implements TokenTransportInterface
+{
+    /**
+     * @param string $key $_SESSION key used to store the token (default: 'auth_token').
+     */
+    public function __construct(private readonly string $key = 'auth_token')
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(): ?string
+    {
+        $token = $_SESSION[$this->key] ?? null;
+
+        return is_string($token) && $token !== '' ? $token : null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(string $token): void
+    {
+        $_SESSION[$this->key] = $token;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): void
+    {
+        unset($_SESSION[$this->key]);
+    }
+}

--- a/src/Transport/TokenTransportInterface.php
+++ b/src/Transport/TokenTransportInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Transport;
+
+/**
+ * Abstracts how the active session token is stored and retrieved on the client side.
+ *
+ * Implement this interface to swap the default PHP session transport for any
+ * other mechanism (Bearer header, cookie, in-memory, etc.).
+ *
+ * @package AuthKit\Transport
+ */
+interface TokenTransportInterface
+{
+    /**
+     * Called once during Auth initialization.
+     *
+     * Use this to start a session, open storage, or perform any setup required
+     * before the transport can be used.
+     *
+     * @return void
+     */
+    public function initialize(): void;
+
+    /**
+     * Return the current token, or null if none is present.
+     *
+     * @return string|null
+     */
+    public function get(): ?string;
+
+    /**
+     * Store the token after a successful login.
+     *
+     * @param  string $token
+     * @return void
+     */
+    public function set(string $token): void;
+
+    /**
+     * Remove the stored token on logout.
+     *
+     * @return void
+     */
+    public function clear(): void;
+}

--- a/src/User.php
+++ b/src/User.php
@@ -126,12 +126,14 @@ class User implements \JsonSerializable
     }
 
     /**
-     * Compatibility helpers.
+     * Returns the user's ID, or null if not yet persisted.
+     *
+     * @return int|string|null
      */
-    public function getId(): ?int
+    public function getId(): int|string|null
     {
         $id = $this->get('id');
-        return is_int($id) ? $id : null;
+        return (is_int($id) || is_string($id)) ? $id : null;
     }
 
     /**

--- a/src/UserId/NullUserIdPolicy.php
+++ b/src/UserId/NullUserIdPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\UserId;
+
+/**
+ * Delegates user ID assignment to the database (auto-increment).
+ *
+ * @package AuthKit\UserId
+ */
+final class NullUserIdPolicy implements UserIdPolicyInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function generate(): int|string|null
+    {
+        return null;
+    }
+}

--- a/src/UserId/UserIdPolicyInterface.php
+++ b/src/UserId/UserIdPolicyInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\UserId;
+
+/**
+ * Determines how a new user ID is assigned before insertion.
+ *
+ * Return null to let the database generate the ID (auto-increment).
+ * Return a value to supply the ID from the application side (e.g. UUID).
+ *
+ * @package AuthKit\UserId
+ */
+interface UserIdPolicyInterface
+{
+    /**
+     * Generate an ID for a new user, or return null to delegate to the database.
+     *
+     * @return int|string|null Application-generated ID, or null for database auto-increment.
+     */
+    public function generate(): int|string|null;
+}

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,36 +1,35 @@
 <?php
 
-use PDO;
-use AuthKit\Auth;
-use AuthKit\User;
-use AuthKit\Storage\PdoUserStorage;
-use AuthKit\Exception\AuthException;
-use PHPUnit\Framework\TestCase;
+declare(strict_types=1);
 
+use AuthKit\Auth;
+use AuthKit\Login;
+use AuthKit\User;
+use AuthKit\Exception\AuthException;
+use AuthKit\Storage\PdoUserStorage;
+use PHPUnit\Framework\TestCase;
 
 class AuthTest extends TestCase
 {
     /**
      * @var PDO
      */
-    // This property holds the PDO instance used for database operations.
     private PDO $pdo;
 
     /**
      * @var Auth
      */
-    // This property holds the Auth instance used for authentication operations.
-    // It is initialized in the setUp() method and used in the test methods to perform
-    // user registration, login, and logout operations.
-    // The Auth instance interacts with the PdoUserStorage to manage user sessions and authentication.
-    // It provides methods for registering users, logging them in, checking if a user is logged
-    // in, and logging them out.
     private Auth $auth;
 
     /**
-     * Sets up the test environment.
-     * Initializes a PDO connection to an in-memory SQLite database,
-     * creates the user storage schema, and initializes the Auth instance.
+     * @var Auth Auth instance with throwExceptions enabled.
+     */
+    private Auth $authStrict;
+
+    /**
+     * Initialises an in-memory SQLite database and two Auth instances:
+     * - $auth        — default (returns Login on failure)
+     * - $authStrict  — throwExceptions: true (throws AuthException on failure)
      */
     protected function setUp(): void
     {
@@ -39,41 +38,62 @@ class AuthTest extends TestCase
 
         $storage = new PdoUserStorage($this->pdo);
         $storage->createSchema();
-        $this->auth = new Auth($storage, null, 600);
+
+        $this->auth       = new Auth($storage, null, 600);
+        $this->authStrict = new Auth($storage, null, 600, null, true);
     }
 
     /**
-     * Cleans up the test environment.
-     * Closes the PDO connection.
+     * Successful registration followed by a successful login.
      */
     public function testRegisterAndLogin(): void
     {
-        $user = $this->auth->register("test@example.com", "Password123!", ["active" => 1]);
+        $user = $this->auth->register('test@example.com', 'Password123!', ['active' => 1]);
         $this->assertInstanceOf(User::class, $user);
 
-        $token = $this->auth->login("test@example.com", "Password123!");
-        $this->assertIsString($token);
+        $login = $this->auth->login('test@example.com', 'Password123!');
+        $this->assertInstanceOf(Login::class, $login);
+        $this->assertTrue($login->isSuccess());
+        $this->assertIsString($login->token());
+        $this->assertNotEmpty($login->token());
         $this->assertTrue($this->auth->isLoggedIn());
 
         $loggedInUser = $this->auth->getUser();
         $this->assertInstanceOf(User::class, $loggedInUser);
-        $this->assertEquals("test@example.com", $loggedInUser->get("email"));
+        $this->assertEquals('test@example.com', $loggedInUser->get('email'));
     }
 
-    // Tests the registration of a user with valid credentials.
+    /**
+     * Login with a wrong password returns Login::failure() by default.
+     */
     public function testLoginFailureWrongPassword(): void
     {
-        $this->auth->register("fail@example.com", "CorrectPass1!");
+        $this->auth->register('fail@example.com', 'CorrectPass1!');
 
-        $this->expectException(AuthException::class);
-        $this->auth->login("fail@example.com", "WrongPassword!");
+        $login = $this->auth->login('fail@example.com', 'WrongPassword!');
+        $this->assertInstanceOf(Login::class, $login);
+        $this->assertTrue($login->isFailure());
+        $this->assertNotEmpty($login->message());
     }
 
-    // Tests the login failure when the user does not exist.
+    /**
+     * Login with a wrong password throws AuthException when throwExceptions is enabled.
+     */
+    public function testLoginFailureThrowsWhenStrictMode(): void
+    {
+        $this->authStrict->register('strict@example.com', 'CorrectPass1!');
+
+        $this->expectException(AuthException::class);
+        $this->authStrict->login('strict@example.com', 'WrongPassword!');
+    }
+
+    /**
+     * Successful logout clears the session.
+     */
     public function testLogout(): void
     {
-        $this->auth->register("logout@example.com", "SecurePass123!");
-        $this->auth->login("logout@example.com", "SecurePass123!");
+        $this->auth->register('logout@example.com', 'SecurePass123!');
+        $this->auth->login('logout@example.com', 'SecurePass123!');
         $this->assertTrue($this->auth->isLoggedIn());
 
         $this->auth->logout();


### PR DESCRIPTION
## Summary

Complete v2 rewrite introducing a pluggable, extensible authentication pipeline. Breaking changes are intentional — this is a new major version.

### Login pipeline

- `login()` now returns `Login` (was: `string|null`) with three states: success / failure / challenge
- `addLoginExtension(LoginExtensionInterface)` — extensions run after credentials pass; first deny or challenge terminates the pipeline
- `LoginContext` carries the verified user, IP, user-agent, and credential metadata for extension decisions
- `LoginDecision::allow()` / `deny()` / `challenge()` — returned by extensions

### Challenge flows (MFA, email activation, etc.)

- `ChallengeExtensionInterface` — extensions that require a second step implement `supportsChallenge()` and `completeChallenge()`
- `completeChallenge(string $token, array $input): Login` — completes a pending challenge and creates a session on success
- `LoginDecision::challenge()` accepts optional `$message`, `$expiresAt`, `$maxAttempts` — extension controls TTL and attempt limits
- Only explicit `isAllow()` from `completeChallenge()` creates a session; any other decision increments attempt counter

### Credential providers

- `CredentialProviderInterface::verify(array $credentials, array $context = []): CredentialResult` — swappable credential backend
- `CredentialResult` carries optional provider metadata (`meta`) forwarded to `LoginContext::$credentialMeta`
- Login extensions can branch on `$ctx->credential('provider')`, `$ctx->credential('email_verified')`, etc.
- `PdoCredentialProvider` — default implementation; explicitly rejects `NULL` password_hash accounts
- `password_hash` is now `NULL` in schema to support external providers (Cognito, Keycloak, Authentik) without a local password

### Token transport

- `TokenTransportInterface` — abstracts where the active token is stored and read
- `PhpSessionTransport($key = 'auth_token')` — default, configurable session key
- `BearerHeaderTransport` — reads `Authorization: Bearer <token>`; set/clear are no-ops

### Clock injection

- `ClockInterface` with `now(): DateTimeImmutable` — own interface, PSR-20 compatible signature
- `SystemClock(DateTimeZone|string $timezone = 'UTC')` — built-in implementation
- `Auth` accepts `clock:` (full `ClockInterface`) or `timezone:` (string) — clock takes precedence
- Storage methods receive `DateTimeImmutable $now` from Auth; `purgeExpiredTokens()` and `purgeExpired()` require explicit `$now` from the caller

### Other changes

- `UserIdPolicyInterface` + `NullUserIdPolicy` — pluggable ID generation (auto-increment default)
- `PasswordHasherInterface` + `NativePasswordHasher` — pluggable password hashing with auto-rehash
- `User::getId()` returns `int|string|null`
- `composer.json` requires PHP `>=8.1`; `ramsey/uuid` dependency removed
- README rewritten for v2 API with examples for all extension points

## Breaking changes

- `login()` return type changed from `string|null` to `Login`
- `UserStorageInterface::findByToken()` requires `DateTimeImmutable $now` parameter
- `ChallengeStorageInterface::complete()` requires `DateTimeImmutable $now` parameter
- `ChallengeStorageInterface::purgeExpired()` requires `DateTimeImmutable $now` parameter
- `PdoUserStorage::purgeExpiredTokens()` requires `DateTimeImmutable $now` parameter
- `Auth` constructor: `$sessionKey` removed; replaced by `transport:` and `clock:`/`timezone:` named params
- `setSessionKey()` removed