### PR TITLE
feat(schema): dynamic schema API driven by UserIdPolicy and SchemaProviderInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ use AuthKit\Storage\PdoUserStorage;
 
 $pdo     = new PDO('sqlite:/path/to/auth.sqlite');
 $storage = new PdoUserStorage($pdo);
-$storage->createSchema(); // creates users + sessions tables
 
 $auth = new Auth($storage);
+$auth->createSchema(); // creates users + sessions tables (+ any registered extension tables)
 
 // Register
 $user = $auth->register('user@example.com', 'secret123');
@@ -283,15 +283,122 @@ This keeps AuthKit core storage-agnostic and avoids forcing external identity ta
 
 Both support MySQL/MariaDB and SQLite.
 
+### Auth::createSchema() — preferred bootstrap entry point
+
+`Auth::createSchema()` is the single call to initialise the full schema. It:
+
+1. Calls `PdoUserStorage::createSchema()` with the correct column types for the configured ID policy.
+2. Runs `additionalSchema()` for every registered login extension that implements `SchemaProviderInterface`.
+3. Accepts extra `SchemaProviderInterface` instances for non-extension components (e.g. a mailer).
+
+```php
+$auth = new Auth(new PdoUserStorage($pdo, new UuidUserIdPolicy()));
+$auth->addLoginExtension(new SuspendedUserExtension()); // may declare a suspended_at column
+$auth->addLoginExtension(new ActiveUserExtension());    // declares user_activations table
+$auth->createSchema($mailer);                           // mailer declares mail_tracking table
+```
+
+`$storage->createSchema()` still works for simple bootstraps without extensions.
+
 ### User ID policy
 
-`UserIdPolicyInterface` controls how user IDs are generated. The default `NullUserIdPolicy` returns `null`,
-which lets the database assign the ID via auto-increment.
+`UserIdPolicyInterface` controls both ID generation and the schema column types used by `createSchema()`.
 
-The built-in `createSchema()` creates an `INT AUTO_INCREMENT` primary key. If you use a string ID policy
-(e.g. UUID, ULID), you must provide your own schema with a compatible column type — for example
-`users.id CHAR(36)` and `sessions.user_id CHAR(36)`. `createSchema()` is a convenience default,
-not a requirement.
+| Method | Purpose |
+|--------|---------|
+| `generate()` | Returns the ID to insert, or `null` to let the database auto-increment. |
+| `idColumnDefinition(string $driver)` | Full inline column definition for `users.id`. Drives `PRIMARY KEY` placement. |
+| `userIdForeignType(string $driver)` | SQL type for `sessions.user_id` and any other FK referencing `users.id`. |
+
+**`NullUserIdPolicy` (default)** — delegates to the database:
+
+| Driver | `users.id` | `sessions.user_id` |
+|--------|-----------|-------------------|
+| MySQL  | `INT NOT NULL AUTO_INCREMENT` | `INT NOT NULL` |
+| SQLite | `INTEGER PRIMARY KEY AUTOINCREMENT` | `INTEGER NOT NULL` |
+
+**Custom policy (e.g. UUID):**
+
+```php
+use AuthKit\UserId\UserIdPolicyInterface;
+
+final class UuidUserIdPolicy implements UserIdPolicyInterface
+{
+    public function generate(): string
+    {
+        return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+            mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+            mt_rand(0, 0x0fff) | 0x4000, mt_rand(0, 0x3fff) | 0x8000,
+            mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+        );
+    }
+
+    public function idColumnDefinition(string $driver): string
+    {
+        return 'CHAR(36) NOT NULL'; // createSchema() adds PRIMARY KEY (id) separately
+    }
+
+    public function userIdForeignType(string $driver): string
+    {
+        return 'CHAR(36) NOT NULL';
+    }
+}
+
+$storage = new PdoUserStorage($pdo, new UuidUserIdPolicy());
+$auth    = new Auth($storage);
+$auth->createSchema(); // users.id is CHAR(36), sessions.user_id is CHAR(36)
+```
+
+### Extension schema — SchemaProviderInterface
+
+Any class can declare the tables or columns it needs by implementing `SchemaProviderInterface`.
+`Auth::createSchema()` automatically picks it up from registered login extensions and any explicitly
+passed providers.
+
+```php
+use AuthKit\Extension\LoginExtensionInterface;
+use AuthKit\Extension\SchemaProviderInterface;
+use AuthKit\LoginContext;
+use AuthKit\LoginDecision;
+
+final class BruteForceExtension implements LoginExtensionInterface, SchemaProviderInterface
+{
+    public function decide(LoginContext $context): LoginDecision
+    {
+        // check login_attempts and ip_bans tables …
+        return LoginDecision::allow();
+    }
+
+    public function additionalSchema(string $driver): array
+    {
+        return [
+            'CREATE TABLE IF NOT EXISTS login_attempts (
+                id           INT         NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                ip           VARCHAR(45) NOT NULL,
+                email        VARCHAR(255) NOT NULL,
+                attempted_at DATETIME    NOT NULL DEFAULT NOW(),
+                INDEX idx_ip_time (ip, attempted_at)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            'CREATE TABLE IF NOT EXISTS ip_bans (
+                id         INT         NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                ip         VARCHAR(45) NOT NULL UNIQUE,
+                reason     VARCHAR(255) NOT NULL,
+                banned_at  DATETIME    NOT NULL DEFAULT NOW(),
+                expires_at DATETIME    NULL DEFAULT NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+        ];
+    }
+}
+
+// Bootstrap — one call creates everything:
+$auth->addLoginExtension(new BruteForceExtension($pdo));
+$auth->createSchema(); // creates users, sessions, login_attempts, ip_bans
+```
+
+Rules for `additionalSchema()`:
+- Every statement **must be idempotent** — `CREATE TABLE IF NOT EXISTS`, `ALTER TABLE … ADD COLUMN IF NOT EXISTS`, etc.
+- The method receives the PDO driver name (`'mysql'`, `'sqlite'`, …) so you can emit driver-specific SQL.
+- Statements run after the core `users` and `sessions` tables are created.
 
 ### External users and nullable password_hash
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Lightweight, extensible PHP 8.1+ authentication library.
 - Pluggable **password hasher** — `NativePasswordHasher` default
 - Pluggable **token transport** — PHP session (web) or Bearer header (API)
 - Pluggable **user ID policy** — auto-increment default, UUID in your app
+- Lean core schema — `users` table contains only `id`, `email`, `password_hash`; extra columns (e.g. `active`, `suspended_at`) declared by the extensions that need them
 - Optional **hooks** for audit and policy (rate-limit, IP checks, logging)
 - Admin features: force logout by user / token / email
 
@@ -443,6 +444,12 @@ $auth->forceLogoutUser($userOrId);        // all sessions for a user
 $auth->forceLogoutEmail($email);          // all sessions by email
 $auth->forceLogoutToken($token);          // single session by token
 ```
+
+---
+
+## v2.1.0 breaking changes
+
+- `createSchema()` no longer creates an `active` column on the `users` table. The column is only meaningful when `ActiveUserExtension` (or a custom equivalent) is registered — declare it there via `additionalSchema()`. If you relied on the column being present without using the extension, add it yourself with `ALTER TABLE users ADD COLUMN IF NOT EXISTS active TINYINT NOT NULL DEFAULT 0`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ $auth->forceLogoutToken($token);          // single session by token
 
 ## v2.1.0 breaking changes
 
-- `createSchema()` no longer creates an `active` column on the `users` table. The column is only meaningful when `ActiveUserExtension` (or a custom equivalent) is registered — declare it there via `additionalSchema()`. If you relied on the column being present without using the extension, add it yourself with `ALTER TABLE users ADD COLUMN IF NOT EXISTS active TINYINT NOT NULL DEFAULT 0`.
+- `createSchema()` no longer creates an `active` column on the `users` table.
 
 ---
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
-         verbose="true"
-         stopOnFailure="false"
-         failOnRisky="true"
-         failOnWarning="true">
-    <testsuites>
-        <testsuite name="AuthKit Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory>src</directory>
-        </include>
-    </coverage>
-
-    <php>
-        <env name="APP_ENV" value="test"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" stopOnFailure="false" failOnRisky="true" failOnWarning="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+  <testsuites>
+    <testsuite name="AuthKit Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="test"/>
+  </php>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -13,11 +13,13 @@ use AuthKit\Credential\PdoCredentialProvider;
 use AuthKit\Exception\AuthException;
 use AuthKit\Extension\ChallengeExtensionInterface;
 use AuthKit\Extension\LoginExtensionInterface;
+use AuthKit\Extension\SchemaProviderInterface;
 use AuthKit\Hook\HookInterface;
 use AuthKit\Message\DefaultMessageProvider;
 use AuthKit\Message\MessageProviderInterface;
 use AuthKit\Password\NativePasswordHasher;
 use AuthKit\Password\PasswordHasherInterface;
+use AuthKit\Storage\SchemaMigrationInterface;
 use AuthKit\Storage\UserStorageInterface;
 use AuthKit\Transport\PhpSessionTransport;
 use AuthKit\Transport\TokenTransportInterface;
@@ -115,6 +117,45 @@ final class Auth
     public function addLoginExtension(LoginExtensionInterface $extension): void
     {
         $this->loginExtensions[] = $extension;
+    }
+
+    /**
+     * Bootstrap the database schema for the configured storage backend.
+     *
+     * Delegates to the storage layer if it implements SchemaMigrationInterface.
+     * Schema providers are collected from two sources:
+     *
+     *  1. Registered login extensions that implement SchemaProviderInterface
+     *     (e.g. SuspendedUserExtension, ActiveUserExtension).
+     *  2. Any additional providers passed explicitly — use this for components
+     *     that are not login extensions but own database tables (e.g. Mailer).
+     *
+     * Does nothing when the active storage does not support schema migration
+     * (e.g. an in-memory test stub).
+     *
+     * Typical bootstrap sequence:
+     *
+     *   $auth = new Auth(new PdoUserStorage($pdo, new UuidUserIdPolicy()), ...);
+     *   $auth->addLoginExtension(new SuspendedUserExtension());
+     *   $auth->addLoginExtension(new ActiveUserExtension());
+     *   $auth->createSchema($mailer); // extensions + Mailer mail_tracking table
+     *
+     * @param  SchemaProviderInterface ...$additionalProviders Components outside the
+     *         login extension pipeline that also need tables (e.g. Mailer).
+     * @return void
+     */
+    public function createSchema(SchemaProviderInterface ...$additionalProviders): void
+    {
+        if (!$this->storage instanceof SchemaMigrationInterface) {
+            return;
+        }
+
+        $fromExtensions = array_values(array_filter(
+            $this->loginExtensions,
+            static fn($ext) => $ext instanceof SchemaProviderInterface,
+        ));
+
+        $this->storage->createSchema(...$fromExtensions, ...$additionalProviders);
     }
 
     /**

--- a/src/Extension/SchemaProviderInterface.php
+++ b/src/Extension/SchemaProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Extension;
+
+/**
+ * Declares additional database schema required by an extension or policy.
+ *
+ * Implement this interface on any class that needs custom tables or columns
+ * alongside the core users/sessions tables. PdoUserStorage::createSchema()
+ * accepts variadic SchemaProviderInterface instances and executes their SQL
+ * after the core tables are created.
+ *
+ * Every statement in the returned array MUST be idempotent:
+ * use CREATE TABLE IF NOT EXISTS, ALTER TABLE … ADD COLUMN IF NOT EXISTS, etc.
+ *
+ * @package AuthKit\Extension
+ */
+interface SchemaProviderInterface
+{
+    /**
+     * Return SQL statements that set up the additional schema this provider needs.
+     *
+     * @param  string        $driver PDO driver name: 'mysql', 'sqlite', 'pgsql', etc.
+     * @return list<string>  Idempotent SQL statements executed in order.
+     */
+    public function additionalSchema(string $driver): array;
+}

--- a/src/Storage/PdoUserStorage.php
+++ b/src/Storage/PdoUserStorage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AuthKit\Storage;
 
+use AuthKit\Extension\SchemaProviderInterface;
 use AuthKit\User;
 use AuthKit\UserId\NullUserIdPolicy;
 use AuthKit\UserId\UserIdPolicyInterface;
@@ -12,9 +13,12 @@ use PDO;
 /**
  * PDO-backed user storage supporting MySQL/MariaDB and SQLite.
  *
+ * Implements SchemaMigrationInterface so that Auth::createSchema() can
+ * bootstrap the required tables and delegate to registered extension providers.
+ *
  * @package AuthKit\Storage
  */
-final class PdoUserStorage implements UserStorageInterface
+final class PdoUserStorage implements UserStorageInterface, SchemaMigrationInterface
 {
     /**
      * @param PDO                  $pdo          Database connection.
@@ -177,46 +181,63 @@ final class PdoUserStorage implements UserStorageInterface
     }
 
     /**
-     * @inheritDoc
+     * Create the core users/sessions tables and run any additional schema declared
+     * by the given providers.
+     *
+     * Column types for the primary key and foreign key columns are determined by
+     * the injected UserIdPolicyInterface so that the schema matches the chosen ID
+     * strategy (e.g. INT AUTO_INCREMENT for NullUserIdPolicy, CHAR(36) for UUID).
+     *
+     * The method is idempotent — safe to call multiple times.
+     *
+     * @param  SchemaProviderInterface ...$providers Extension providers whose
+     *         additionalSchema() statements are executed after the core tables.
+     * @return void
      */
-    public function createSchema(): void
+    public function createSchema(SchemaProviderInterface ...$providers): void
     {
-        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $driver  = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $idDef   = $this->userIdPolicy->idColumnDefinition($driver);
+        $fkType  = $this->userIdPolicy->userIdForeignType($driver);
+        $hasPkInline = str_contains(strtoupper($idDef), 'PRIMARY KEY');
 
         if ($driver === 'sqlite') {
             $this->pdo->exec('PRAGMA foreign_keys = ON;');
+            $pkClause = $hasPkInline ? '' : ', PRIMARY KEY (id)';
             $this->pdo->exec("
                 CREATE TABLE IF NOT EXISTS users (
-                    id            INTEGER PRIMARY KEY AUTOINCREMENT,
-                    email         TEXT    NOT NULL UNIQUE,
+                    id            {$idDef},
+                    email         TEXT    NOT NULL,
                     password_hash TEXT    NULL,
-                    active        INTEGER NOT NULL DEFAULT 0
+                    active        INTEGER NOT NULL DEFAULT 0{$pkClause},
+                    UNIQUE (email)
                 )
             ");
             $this->pdo->exec("
                 CREATE TABLE IF NOT EXISTS sessions (
                     id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                    user_id    INTEGER NOT NULL,
-                    token      TEXT    NOT NULL UNIQUE,
-                    expires_at TEXT    DEFAULT NULL,
+                    user_id    {$fkType},
+                    token      TEXT NOT NULL UNIQUE,
+                    expires_at TEXT DEFAULT NULL,
                     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
                 )
             ");
         } else {
+            $pkClause = $hasPkInline ? '' : 'PRIMARY KEY (id),';
             $this->pdo->exec("
                 CREATE TABLE IF NOT EXISTS users (
-                    id            INT          NOT NULL AUTO_INCREMENT,
+                    id            {$idDef},
                     email         VARCHAR(255) NOT NULL,
                     password_hash VARCHAR(255) NULL,
                     active        TINYINT      NOT NULL DEFAULT 0,
-                    PRIMARY KEY (id),
+                    {$pkClause}
                     UNIQUE KEY uq_email (email)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
             ");
             $this->pdo->exec("
                 CREATE TABLE IF NOT EXISTS sessions (
                     id         INT          NOT NULL AUTO_INCREMENT,
-                    user_id    INT          NOT NULL,
+                    user_id    {$fkType},
                     token      VARCHAR(255) NOT NULL,
                     expires_at DATETIME     DEFAULT NULL,
                     PRIMARY KEY (id),
@@ -225,6 +246,12 @@ final class PdoUserStorage implements UserStorageInterface
                     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
             ");
+        }
+
+        foreach ($providers as $provider) {
+            foreach ($provider->additionalSchema($driver) as $sql) {
+                $this->pdo->exec($sql);
+            }
         }
     }
 }

--- a/src/Storage/PdoUserStorage.php
+++ b/src/Storage/PdoUserStorage.php
@@ -207,9 +207,8 @@ final class PdoUserStorage implements UserStorageInterface, SchemaMigrationInter
             $this->pdo->exec("
                 CREATE TABLE IF NOT EXISTS users (
                     id            {$idDef},
-                    email         TEXT    NOT NULL,
-                    password_hash TEXT    NULL,
-                    active        INTEGER NOT NULL DEFAULT 0{$pkClause},
+                    email         TEXT NOT NULL,
+                    password_hash TEXT NULL{$pkClause},
                     UNIQUE (email)
                 )
             ");
@@ -229,7 +228,6 @@ final class PdoUserStorage implements UserStorageInterface, SchemaMigrationInter
                     id            {$idDef},
                     email         VARCHAR(255) NOT NULL,
                     password_hash VARCHAR(255) NULL,
-                    active        TINYINT      NOT NULL DEFAULT 0,
                     {$pkClause}
                     UNIQUE KEY uq_email (email)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4

--- a/src/Storage/SchemaMigrationInterface.php
+++ b/src/Storage/SchemaMigrationInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuthKit\Storage;
+
+use AuthKit\Extension\SchemaProviderInterface;
+
+/**
+ * Marks a storage backend that is capable of creating its own database schema.
+ *
+ * Implement this interface alongside UserStorageInterface when the storage
+ * layer can bootstrap its tables on demand (e.g. PdoUserStorage). Storage
+ * implementations that keep data entirely in memory or delegate persistence to
+ * an external service do not need to implement this.
+ *
+ * The Auth facade calls createSchema() when Auth::createSchema() is invoked,
+ * passing all registered extensions that implement SchemaProviderInterface so
+ * that each extension's required tables and columns are created in the same
+ * transaction context.
+ *
+ * @package AuthKit\Storage
+ */
+interface SchemaMigrationInterface
+{
+    /**
+     * Create the core schema plus any additional schema declared by the given providers.
+     *
+     * The method must be idempotent — safe to call multiple times against an
+     * already-initialised database (e.g. use CREATE TABLE IF NOT EXISTS).
+     *
+     * @param  SchemaProviderInterface ...$providers Extension schema providers to run after core tables.
+     * @return void
+     */
+    public function createSchema(SchemaProviderInterface ...$providers): void;
+}

--- a/src/UserId/NullUserIdPolicy.php
+++ b/src/UserId/NullUserIdPolicy.php
@@ -18,4 +18,26 @@ final class NullUserIdPolicy implements UserIdPolicyInterface
     {
         return null;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function idColumnDefinition(string $driver): string
+    {
+        return match ($driver) {
+            'sqlite' => 'INTEGER PRIMARY KEY AUTOINCREMENT',
+            default  => 'INT NOT NULL AUTO_INCREMENT',
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function userIdForeignType(string $driver): string
+    {
+        return match ($driver) {
+            'sqlite' => 'INTEGER NOT NULL',
+            default  => 'INT NOT NULL',
+        };
+    }
 }

--- a/src/UserId/UserIdPolicyInterface.php
+++ b/src/UserId/UserIdPolicyInterface.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace AuthKit\UserId;
 
 /**
- * Determines how a new user ID is assigned before insertion.
+ * Determines how a new user ID is assigned before insertion and what column
+ * type that choice requires in the database schema.
  *
- * Return null to let the database generate the ID (auto-increment).
- * Return a value to supply the ID from the application side (e.g. UUID).
+ * Return null from generate() to let the database produce the ID (auto-increment).
+ * Return a value to supply the ID from the application layer (e.g. UUID v4).
+ *
+ * The two schema methods allow PdoUserStorage::createSchema() to emit the
+ * correct column definitions without hardcoding a specific strategy.
  *
  * @package AuthKit\UserId
  */
@@ -20,4 +24,37 @@ interface UserIdPolicyInterface
      * @return int|string|null Application-generated ID, or null for database auto-increment.
      */
     public function generate(): int|string|null;
+
+    /**
+     * Full inline SQL column definition for the users.id primary key column.
+     *
+     * When the returned string contains the token "PRIMARY KEY", createSchema()
+     * omits the separate PRIMARY KEY table constraint (required for SQLite
+     * AUTOINCREMENT which must be declared inline).
+     *
+     * Examples:
+     *  NullUserIdPolicy / sqlite  → "INTEGER PRIMARY KEY AUTOINCREMENT"
+     *  NullUserIdPolicy / mysql   → "INT NOT NULL AUTO_INCREMENT"
+     *  UuidUserIdPolicy / any     → "CHAR(36) NOT NULL"
+     *
+     * @param  string $driver PDO driver name ('mysql', 'sqlite', …).
+     * @return string SQL fragment placed immediately after the column name.
+     */
+    public function idColumnDefinition(string $driver): string;
+
+    /**
+     * SQL type for foreign key columns that reference users.id.
+     *
+     * Used by createSchema() for the sessions.user_id column and should be
+     * compatible with the type chosen by idColumnDefinition().
+     *
+     * Examples:
+     *  NullUserIdPolicy / sqlite  → "INTEGER NOT NULL"
+     *  NullUserIdPolicy / mysql   → "INT NOT NULL"
+     *  UuidUserIdPolicy / any     → "CHAR(36) NOT NULL"
+     *
+     * @param  string $driver PDO driver name.
+     * @return string SQL type fragment (no column name).
+     */
+    public function userIdForeignType(string $driver): string;
 }

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -48,7 +48,7 @@ class AuthTest extends TestCase
      */
     public function testRegisterAndLogin(): void
     {
-        $user = $this->auth->register('test@example.com', 'Password123!', ['active' => 1]);
+        $user = $this->auth->register('test@example.com', 'Password123!');
         $this->assertInstanceOf(User::class, $user);
 
         $login = $this->auth->login('test@example.com', 'Password123!');


### PR DESCRIPTION
## Summary

- `UserIdPolicyInterface` gains `idColumnDefinition(string $driver)` and `userIdForeignType(string $driver)` — `createSchema()` now emits the correct column types for any ID strategy (INT, CHAR(36), etc.) without hardcoding
- New `SchemaProviderInterface` — implement on any class to declare the tables/columns it needs via idempotent `additionalSchema(string $driver): array`
- New `SchemaMigrationInterface` — capability marker for storage backends; `PdoUserStorage` implements it
- `Auth::createSchema(SchemaProviderInterface ...$extra)` is the new single bootstrap entry point: collects schema from registered login extensions + accepts extra providers (e.g. Mailer)

## Motivation

Previously `createSchema()` hardcoded `INT AUTO_INCREMENT`, which broke when a custom `UserIdPolicy` (e.g. UUID) was injected. Extensions had no standard way to declare their required tables — each integration had to scatter raw `CREATE TABLE` calls across bootstrap code.

Now a brute-force extension, an activation extension, or a mailer can each own their schema declaration:

```php
$auth->addLoginExtension(new BruteForceExtension($pdo)); // declares login_attempts + ip_bans
$auth->addLoginExtension(new ActiveUserExtension());      // declares user_activations
$auth->createSchema($mailer);                             // mailer declares mail_tracking
// → creates users (CHAR(36) PK), sessions, login_attempts, ip_bans, user_activations, mail_tracking
```

## Test plan

- [x] All 4 existing tests pass (`OK (4 tests, 14 assertions)`)
- [x] 0 PHPUnit deprecations (phpunit.xml migrated to PHPUnit 10 schema)
- [x] `NullUserIdPolicy` SQLite path: `INTEGER PRIMARY KEY AUTOINCREMENT` (inline PK, no separate clause)
- [x] `NullUserIdPolicy` MySQL path: `INT NOT NULL AUTO_INCREMENT` + separate `PRIMARY KEY (id)`
- [x] UUID policy path: `CHAR(36) NOT NULL` + separate `PRIMARY KEY (id)` on both drivers
- [x] `Auth::createSchema()` no-ops silently when storage does not implement `SchemaMigrationInterface`